### PR TITLE
Update application status terminology

### DIFF
--- a/specs/001-job-application-tracker/contracts/storage-service.ts
+++ b/specs/001-job-application-tracker/contracts/storage-service.ts
@@ -13,11 +13,12 @@
 
 export type ApplicationStatus =
   | 'applied'
-  | 'interviewing'
-  | 'offered'
   | 'rejected'
-  | 'accepted'
-  | 'declined';
+  | 'interviewing'
+  | 'given offer'
+  | 'accepted offer'
+  | 'declined offer'
+  | 'no offer';
 
 export type CompanyCategory =
   | 'education'

--- a/specs/001-job-application-tracker/data-model.md
+++ b/specs/001-job-application-tracker/data-model.md
@@ -48,7 +48,7 @@ interface JobApplication {
 
   // Related data (embedded)
   interviewStages: InterviewStage[];   // Ordered array
-  offerDueDate?: string;               // ISO 8601 date string (when status = 'offered')
+  offerDueDate?: string;               // ISO 8601 date string (when status = 'given offer')
 
   // Soft delete
   isArchived: boolean;                 // false by default
@@ -86,12 +86,13 @@ interface InterviewStage {
 
 ```typescript
 type ApplicationStatus =
-  | 'applied'      // Initial state
-  | 'interviewing' // Active interview process
-  | 'offered'      // Received offer
-  | 'rejected'     // Application rejected
-  | 'accepted'     // Offer accepted (terminal)
-  | 'declined';    // Offer declined (terminal)
+  | 'applied'        // Initial state
+  | 'rejected'       // Application rejected
+  | 'interviewing'   // Active interview process
+  | 'given offer'    // Received offer
+  | 'accepted offer' // Offer accepted (terminal)
+  | 'declined offer' // Offer declined (terminal)
+  | 'no offer';      // No offer received
 ```
 
 ### CompanyCategory
@@ -204,35 +205,35 @@ function isValidUrl(url: string): boolean {
                            │
               ┌────────────┼────────────┐
               ▼            ▼            ▼
-       ┌────────────┐ ┌─────────┐ ┌──────────┐
-       │interviewing│ │ rejected│ │ archived │
-       └──────┬─────┘ └─────────┘ └──────────┘
+       ┌────────────┐ ┌──────────┐ ┌──────────┐
+       │interviewing│ │ rejected │ │ archived │
+       └──────┬─────┘ └──────────┘ └──────────┘
               │
-      ┌───────┼───────┐
-      ▼       ▼       ▼
-┌─────────┐ ┌───────┐ ┌────────┐
-│ offered │ │rejected│ │applied │ (revert)
-└────┬────┘ └───────┘ └────────┘
+      ┌───────┼────────────┐
+      ▼       ▼            ▼
+┌─────────────┐ ┌──────────┐ ┌────────┐
+│ given offer │ │ no offer │ │applied │ (revert)
+└────┬────────┘ └──────────┘ └────────┘
      │
-     ├───────────┬────────────┐
-     ▼           ▼            ▼
-┌──────────┐ ┌─────────┐ ┌────────────┐
-│ accepted │ │ declined│ │interviewing│ (if more rounds)
-└──────────┘ └─────────┘ └────────────┘
+     ├──────────────┬────────────┐
+     ▼              ▼            ▼
+┌──────────────┐ ┌──────────────┐ ┌────────────┐
+│accepted offer│ │declined offer│ │interviewing│ (if more rounds)
+└──────────────┘ └──────────────┘ └────────────┘
 ```
 
 ### Transition Rules
 
 | From | To | Conditions | Side Effects |
 |------|-----|------------|--------------|
-| applied | interviewing | None | Populate default interview stages |
 | applied | rejected | None | None |
-| interviewing | offered | None | None |
-| interviewing | rejected | None | Preserve interview data |
+| applied | interviewing | None | Populate default interview stages |
+| interviewing | given offer | None | None |
+| interviewing | no offer | None | Preserve interview data |
 | interviewing | applied | User action (revert) | Preserve interview data |
-| offered | accepted | None | Terminal state |
-| offered | declined | None | Terminal state |
-| offered | interviewing | User action (more rounds) | None |
+| given offer | accepted offer | None | Terminal state |
+| given offer | declined offer | None | Terminal state |
+| given offer | interviewing | User action (more rounds) | None |
 | any | archived | User action | Set isArchived = true |
 | archived | any | User action (restore) | Set isArchived = false |
 

--- a/specs/001-job-application-tracker/plan.md
+++ b/specs/001-job-application-tracker/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Build a single-user job application tracking web application that allows users to add, view, filter, and manage job applications through the entire application lifecycle (Applied → Interviewing → Offered/Rejected). The application will be built with Next.js and React, using local browser storage (localStorage) for persistence, with a responsive Tailwind CSS interface optimized for both mobile and desktop.
+Build a single-user job application tracking web application that allows users to add, view, filter, and manage job applications through the entire application lifecycle (Applied → Rejected → Interviewing → Given Offer/No Offer → Accepted Offer/Declined Offer). The application will be built with Next.js and React, using local browser storage (localStorage) for persistence, with a responsive Tailwind CSS interface optimized for both mobile and desktop.
 
 ## Technical Context
 

--- a/specs/001-job-application-tracker/quickstart.md
+++ b/specs/001-job-application-tracker/quickstart.md
@@ -125,12 +125,13 @@ const config: Config = {
       colors: {
         // Custom colors for status badges
         status: {
-          applied: '#3B82F6',      // blue-500
-          interviewing: '#F59E0B', // amber-500
-          offered: '#10B981',      // emerald-500
-          rejected: '#EF4444',     // red-500
-          accepted: '#22C55E',     // green-500
-          declined: '#6B7280',     // gray-500
+          applied: '#3B82F6',           // blue-500
+          rejected: '#EF4444',          // red-500
+          interviewing: '#F59E0B',      // amber-500
+          'given offer': '#10B981',     // emerald-500
+          'accepted offer': '#22C55E',  // green-500
+          'declined offer': '#6B7280',  // gray-500
+          'no offer': '#EF4444',        // red-500
         },
       },
     },

--- a/specs/001-job-application-tracker/spec.md
+++ b/specs/001-job-application-tracker/spec.md
@@ -95,11 +95,11 @@ As a job seeker who has received an offer, I want to track offer details includi
 
 **Why this priority**: Offer management is time-sensitive and critical for users who reach this stage. Missing an offer deadline could have significant consequences.
 
-**Independent Test**: Can be fully tested by changing an application status to "Offered", setting a due date, and verifying the deadline is visible.
+**Independent Test**: Can be fully tested by changing an application status to "Given Offer", setting a due date, and verifying the deadline is visible.
 
 **Acceptance Scenarios**:
 
-1. **Given** I have an application, **When** I change its status to "Offered", **Then** I can optionally set an offer due date for when I need to respond.
+1. **Given** I have an application, **When** I change its status to "Given Offer", **Then** I can optionally set an offer due date for when I need to respond.
 2. **Given** I have an offer with a due date, **When** I view my applications list, **Then** I can see which offers have upcoming deadlines.
 3. **Given** I have an offer with a due date approaching, **When** I view that application, **Then** I can clearly see the deadline and how many days remain.
 
@@ -154,7 +154,7 @@ As a job seeker, I want to access my job tracker on both my phone and computer s
 **Core Application Fields:**
 - **FR-001**: System MUST allow users to create job applications with required fields: company name and position title
 - **FR-002**: System MUST allow users to set application date (defaults to current date)
-- **FR-003**: System MUST support these application statuses: Applied, Interviewing, Offered, Rejected, Archived
+- **FR-003**: System MUST support these application statuses: Applied, Rejected, Interviewing, Given Offer, Accepted Offer, Declined Offer, No Offer, Archived
 - **FR-004**: System MUST allow users to add free-form notes to any application
 - **FR-019**: System MUST allow users to add an optional company website URL
 - **FR-020**: System MUST allow users to add optional job posting URLs (job site URL such as LinkedIn, and company career page URL)
@@ -181,7 +181,7 @@ As a job seeker, I want to access my job tracker on both my phone and computer s
 - **FR-012**: System MUST allow users to customize interview stages (add, remove, reorder) for individual applications
 
 **Offer Management:**
-- **FR-013**: System MUST allow users to set an optional due date when status is "Offered"
+- **FR-013**: System MUST allow users to set an optional due date when status is "Given Offer"
 
 **Data Management:**
 - **FR-014**: System MUST allow users to archive applications (soft delete - hidden from default view)
@@ -203,7 +203,7 @@ As a job seeker, I want to access my job tracker on both my phone and computer s
 
 - **Interview Stage**: Represents one step in the interview process. Contains stage name/title, order position, completion status, completion date (when complete), optional notes, and optional performance rating (1-5). Belongs to a single Job Application.
 
-- **Offer Details**: Contains offer due date (optional). Associated with Job Applications in "Offered" status.
+- **Offer Details**: Contains offer due date (optional). Associated with Job Applications in "Given Offer" status.
 
 - **Company Category**: Enumeration of industry categories: Education, Health, Climate, AI, FinTech, Enterprise Software, Consumer Tech, E-commerce, Cybersecurity, Gaming, Media/Entertainment, Consulting, Government, Nonprofit, Other.
 

--- a/specs/001-job-application-tracker/tasks.md
+++ b/specs/001-job-application-tracker/tasks.md
@@ -142,9 +142,9 @@
 
 ## Phase 6: User Story 4 - Manage Offers with Due Dates (Priority: P2)
 
-**Goal**: Users can set offer due dates when status is "Offered" and see deadline countdown
+**Goal**: Users can set offer due dates when status is "Given Offer" and see deadline countdown
 
-**Independent Test**: Change application status to "Offered", set due date, verify deadline displays correctly
+**Independent Test**: Change application status to "Given Offer", set due date, verify deadline displays correctly
 
 ### Tests for User Story 4
 
@@ -153,7 +153,7 @@
 ### Implementation for User Story 4
 
 - [x] T056 [P] [US4] Create SVG icon for calendar/deadline in src/assets/icons/CalendarIcon.tsx
-- [x] T057 [US4] Add offerDueDate field handling to ApplicationDetail (status-based editing when "Offered" per FR-013)
+- [x] T057 [US4] Add offerDueDate field handling to ApplicationDetail (status-based editing when "Given Offer" per FR-013)
 - [x] T058 [US4] Add deadline display with days remaining to ApplicationCard in src/components/applications/ApplicationCard.tsx
 - [x] T059 [US4] Add deadline display with countdown to ApplicationDetail in src/components/applications/ApplicationDetail.tsx
 

--- a/src/components/applications/ApplicationCard.tsx
+++ b/src/components/applications/ApplicationCard.tsx
@@ -43,7 +43,7 @@ export function ApplicationCard({
   const totalStages = interviewStages.length;
   const salaryRange = formatSalaryRange(salaryMin, salaryMax);
   const daysRemaining = offerDueDate ? getDaysRemaining(offerDueDate) : null;
-  const isOffered = status === 'offered';
+  const isOffered = status === 'given offer';
 
   return (
     <Card

--- a/src/components/applications/ApplicationDetail.tsx
+++ b/src/components/applications/ApplicationDetail.tsx
@@ -97,11 +97,11 @@ export function ApplicationDetail({
   const salaryRange = formatSalaryRange(application.salaryMin, application.salaryMax);
   const showInterviewSection =
     application.status === 'interviewing' ||
-    application.status === 'offered' ||
-    application.status === 'accepted' ||
+    application.status === 'given offer' ||
+    application.status === 'accepted offer' ||
     application.interviewStages.length > 0;
 
-  const isOffered = application.status === 'offered';
+  const isOffered = application.status === 'given offer';
   const daysRemaining = application.offerDueDate ? getDaysRemaining(application.offerDueDate) : null;
 
   return (

--- a/src/components/applications/ApplicationForm.tsx
+++ b/src/components/applications/ApplicationForm.tsx
@@ -235,7 +235,7 @@ export function ApplicationForm({
           />
         )}
 
-        {mode === 'edit' && formData.status === 'offered' && (
+        {mode === 'edit' && formData.status === 'given offer' && (
           <Input
             label="Offer Due Date"
             name="offerDueDate"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -31,31 +31,34 @@ export const DEFAULT_INTERVIEW_STAGES: Omit<InterviewStage, 'id'>[] = [
 export const APPLICATION_STATUSES: ApplicationStatus[] = [
   'unsubmitted',
   'applied',
-  'interviewing',
-  'offered',
   'rejected',
-  'accepted',
-  'declined',
+  'interviewing',
+  'given offer',
+  'accepted offer',
+  'declined offer',
+  'no offer',
 ];
 
 export const STATUS_LABELS: Record<ApplicationStatus, string> = {
   unsubmitted: 'Unsubmitted',
   applied: 'Applied',
-  interviewing: 'Interviewing',
-  offered: 'Offered',
   rejected: 'Rejected',
-  accepted: 'Accepted',
-  declined: 'Declined',
+  interviewing: 'Interviewing',
+  'given offer': 'Given Offer',
+  'accepted offer': 'Accepted Offer',
+  'declined offer': 'Declined Offer',
+  'no offer': 'No Offer',
 };
 
 export const STATUS_COLORS: Record<ApplicationStatus, string> = {
   unsubmitted: 'bg-status-unsubmitted text-white',
   applied: 'bg-status-applied text-white',
-  interviewing: 'bg-status-interviewing text-white',
-  offered: 'bg-status-offered text-white',
   rejected: 'bg-status-rejected text-white',
-  accepted: 'bg-status-accepted text-white',
-  declined: 'bg-status-declined text-white',
+  interviewing: 'bg-status-interviewing text-white',
+  'given offer': 'bg-status-offered text-white',
+  'accepted offer': 'bg-status-accepted text-white',
+  'declined offer': 'bg-status-declined text-white',
+  'no offer': 'bg-status-rejected text-white',
 };
 
 // ============================================================================

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -10,11 +10,12 @@
 export type ApplicationStatus =
   | 'unsubmitted'
   | 'applied'
-  | 'interviewing'
-  | 'offered'
   | 'rejected'
-  | 'accepted'
-  | 'declined';
+  | 'interviewing'
+  | 'given offer'
+  | 'accepted offer'
+  | 'declined offer'
+  | 'no offer';
 
 export type CompanyCategory =
   | 'education'


### PR DESCRIPTION
This pull request updates the job application tracker to provide a more granular and descriptive set of application statuses, especially around the offer stage. The changes affect the data model, user interface, documentation, and configuration to consistently use new statuses such as "Given Offer", "Accepted Offer", "Declined Offer", and "No Offer" instead of the previous "Offered", "Accepted", and "Declined". This improves clarity for users and allows for more precise tracking of application outcomes.

**Key changes:**

### Data Model & Type Updates

- Expanded `ApplicationStatus` enum to include `'given offer'`, `'accepted offer'`, `'declined offer'`, and `'no offer'` while removing `'offered'`, `'accepted'`, and `'declined'` in both TypeScript types and markdown specs for consistency across backend and frontend. [[1]](diffhunk://#diff-e8d6fa1843c3f2a439d3119f3b2fb35fd96328e3150434f379f99ba114843499L16-R21) [[2]](diffhunk://#diff-01dd7ec55c548400c23c5c3b83d3432887cd6819a92a40da78042d210f584ca6L90-R95) [[3]](diffhunk://#diff-221deea90057f387efe650a1d04b00dc3329b5b61843a5b053f3637050f95155L13-R18)
- Updated all references to the offer due date field to trigger when status is `'given offer'` instead of `'offered'`.

### UI and Component Logic

- Modified logic in `ApplicationCard`, `ApplicationDetail`, and `ApplicationForm` components to check for `'given offer'` and related new statuses instead of the old `'offered'`, `'accepted'`, and `'declined'` statuses. [[1]](diffhunk://#diff-4ecf8b2095ba006a037383196c2704dc659258ca6bf75994e911f38d52018cf8L46-R46) [[2]](diffhunk://#diff-b6890aee7dcbacf4c9a250182dc4cca75929fc4ce08a24529ad00d51e6c3d11aL100-R104) [[3]](diffhunk://#diff-c86f79af6a9ba9449e49c0d53a5ab3043524d59f7e393366ffed088c02b6a59dL238-R238)
- Updated status labels and colors in `src/lib/constants.ts` to reflect the new statuses and ensure correct badge display. [[1]](diffhunk://#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aL34-R61) [[2]](diffhunk://#diff-f9694fa44a84f5ece3df60c810f9b8ea5654af70c3f14a89a8bb5509ac1d9b2dL129-R134)

### Documentation & Specs

- Revised all documentation, specifications, and test plans to use the new status names and transitions, including summary, feature requirements, acceptance criteria, and diagrams. [[1]](diffhunk://#diff-3ad34c1707c14592caa1b2f000eef8aff83993487a061b297c881767e32d5f4bL8-R8) [[2]](diffhunk://#diff-697f4fa9153d1c2d120dd8e6df4489303df4d1079a4b19df7c27ad2a9fa7eee8L98-R102) [[3]](diffhunk://#diff-697f4fa9153d1c2d120dd8e6df4489303df4d1079a4b19df7c27ad2a9fa7eee8L157-R157) [[4]](diffhunk://#diff-697f4fa9153d1c2d120dd8e6df4489303df4d1079a4b19df7c27ad2a9fa7eee8L184-R184) [[5]](diffhunk://#diff-697f4fa9153d1c2d120dd8e6df4489303df4d1079a4b19df7c27ad2a9fa7eee8L206-R206) [[6]](diffhunk://#diff-a42ff7e42b348e8c3bf167411146c0d6b28902ac40898bac25b0456db6f7bc59L145-R147) [[7]](diffhunk://#diff-a42ff7e42b348e8c3bf167411146c0d6b28902ac40898bac25b0456db6f7bc59L156-R156) [[8]](diffhunk://#diff-01dd7ec55c548400c23c5c3b83d3432887cd6819a92a40da78042d210f584ca6L207-R236)

These changes ensure the application's status handling is more expressive and user-friendly, especially for offer management and tracking application outcomes.