### PR TITLE
feat(skills): add doc updates for major version changes

### DIFF
--- a/.claude/skills/audit-and-fix/SKILL.md
+++ b/.claude/skills/audit-and-fix/SKILL.md
@@ -90,7 +90,37 @@ Generate consolidated security report with:
 
 Prompt: merge fixes, keep for review, or discard.
 
-### 9. Cleanup
+### 9. Update Documentation for Major Version Changes
+
+When security fixes require major version upgrades:
+
+1. **Identify major version changes** across all directories:
+   - Track packages that jumped major versions (e.g., 4.x → 5.x)
+
+2. **Search for version references**:
+   ```bash
+   grep -r "Express 4\|Prisma 5\|React 18" --include="*.md" .
+   ```
+
+3. **Update documentation files** (prioritized):
+   - `CLAUDE.md` - Active technologies
+   - `README.md` - Stack descriptions
+   - `docs/*.md` - Version tables and tech stack sections
+
+4. **Skip historical documents**:
+   - `specs/*/research.md`
+   - `specs/*/tasks.md`
+
+5. **Include in security report**:
+   ```
+   Documentation Updates
+   ---------------------
+   Updated version references in:
+   - CLAUDE.md (React 18 → 19)
+   - docs/API_IMPLEMENTATION_SUMMARY.md (Express 4.18 → 5.x)
+   ```
+
+### 10. Cleanup
 
 ```bash
 git worktree remove "$WORKTREE_PATH"

--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -103,7 +103,47 @@ npm test
 - Offer options: isolate problem, revert specific updates, or abandon
 - If partially successful, still create PR with failing checks noted
 
-### 7. Cleanup
+### 7. Update Documentation for Major Version Changes
+
+When packages have major version upgrades (e.g., 18.x → 19.x, 4.x → 5.x):
+
+1. **Identify major version changes** from the update:
+   ```bash
+   # Compare old vs new versions in package.json changes
+   git diff --cached package.json | grep -E '^\+.*"version"'
+   ```
+
+2. **Search for version references in documentation**:
+   ```bash
+   # Search markdown files for version patterns
+   grep -r "React 18\|Next.js 14\|Express 4\|Prisma 5" --include="*.md" .
+   ```
+
+3. **Files to check** (prioritized):
+   - `CLAUDE.md` - Active technologies section
+   - `README.md` - Stack descriptions
+   - `docs/*.md` - Implementation docs with version tables
+   - `specs/*/plan.md` - Technical context sections
+
+4. **Skip historical documents** (don't update):
+   - `specs/*/research.md` - Original research notes
+   - `specs/*/tasks.md` - Completed task records
+   - Files with "historical" or "archive" in path
+
+5. **Update pattern**: Replace version references like:
+   - `React 18` → `React 19`
+   - `Next.js 14` → `Next.js 16`
+   - `Express 4.18` → `Express 5.x`
+   - `Prisma 5.8` → `Prisma 7.x`
+
+6. **Include in PR description**:
+   ```markdown
+   ## Documentation Updates
+   - Updated version references in X files
+   - [list files with changes]
+   ```
+
+### 8. Cleanup
 
 ```bash
 git worktree remove "$WORKTREE_PATH"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,5 +197,20 @@ cd vue-ui && npm run test:e2e
 - Component tests: `src/components/**/*.test.tsx`
 - Service tests: `src/__tests__/services/*.test.ts`
 
+## Version Documentation Files
+
+When updating packages with major version changes, update version references in these files:
+
+**Always update:**
+- `CLAUDE.md` - Active Technologies section
+- `README.md` - Stack descriptions
+- `docs/IMPLEMENTATION_READY.md` - Technology stack section
+- `docs/API_IMPLEMENTATION_SUMMARY.md` - Technology stack section
+- `specs/001-job-application-tracker/plan.md` - Technical Context section
+
+**Never update (historical records):**
+- `specs/*/research.md` - Original research notes
+- `specs/*/tasks.md` - Completed task records
+
 ## Recent Changes
 - 001-job-application-tracker: Added TypeScript 5.x (strict mode enabled) + React 18, Next.js 14, Tailwind CSS 3.x, Vite (for dev tooling)


### PR DESCRIPTION
## Summary
- Add documentation update step to `update-deps` and `audit-and-fix` skills
- Skills now automatically update version references in markdown files when packages have major version upgrades
- Add configuration section to CLAUDE.md listing which files to update vs skip

## Changes
- `.claude/skills/update-deps/SKILL.md` - Added step 7 for documentation updates
- `.claude/skills/audit-and-fix/SKILL.md` - Added step 9 for documentation updates
- `CLAUDE.md` - Added "Version Documentation Files" section with explicit file lists

## How It Works
When running `update-deps` or `audit-and-fix` with major version changes (e.g., React 18→19, Express 4→5):

1. Skills identify major version jumps
2. Search markdown files for version patterns
3. Update configured files (CLAUDE.md, README.md, docs/*.md, specs/*/plan.md)
4. Skip historical records (research.md, tasks.md)
5. Include documentation updates in PR description

## Test Plan
- [ ] Run `update-deps` with a package that has a major version update
- [ ] Verify documentation files are updated with new version references
- [ ] Verify historical files are not modified

---
🤖 Generated with [Claude Code](https://claude.ai/code)