### PR TITLE
docs: add Vue.js patterns and subagent guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,14 @@ When components manage child resources:
 - Pass individual callbacks (`onAdd`, `onUpdate`, `onRemove`) instead of a single `onChange` with full state
 - This allows parent components to make targeted API calls without needing to diff arrays
 
+## Vue.js Patterns
+
+### Vue Router Component Reuse on Param Change
+When navigating between routes that share the same component (e.g. `/applications/new` → `/applications/:id`), Vue Router reuses the component instance — `onMounted` does not re-fire. Use `watch(() => props.id)` to detect the param change and reload data.
+
+### Navigation Guard Bypass for Programmatic Navigation
+`onBeforeRouteLeave` fires on programmatic `router.push()` calls, not just user-initiated navigation. When a save or delete handler redirects via `router.push()`, a dirty-check guard will block it. Use a `skipNavGuard` ref set to `true` before the `router.push()` call, and check it first in the guard.
+
 ## Running E2E Tests
 
 ### Prerequisites

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,14 @@ When navigating between routes that share the same component (e.g. `/application
 ### Navigation Guard Bypass for Programmatic Navigation
 `onBeforeRouteLeave` fires on programmatic `router.push()` calls, not just user-initiated navigation. When a save or delete handler redirects via `router.push()`, a dirty-check guard will block it. Use a `skipNavGuard` ref set to `true` before the `router.push()` call, and check it first in the guard.
 
+## Subagent Usage
+
+### Prefer Blocking Parallel Over Background Agents
+When launching multiple subagents with no other work to do, use normal (blocking) parallel `Task` calls in a single message — results come back automatically when all complete. Only use `run_in_background: true` when you need to continue doing other work while agents run.
+
+### Monitor Background Agents Proactively
+When background agents are used, proactively check their progress via `TaskOutput`/`Read` and report status to the user. Do not wait silently for the user to ask.
+
 ## Running E2E Tests
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- Add Vue.js Patterns section documenting Vue Router component reuse and navigation guard bypass patterns discovered during inline edit UI implementation
- Add Subagent Usage section with guidelines for parallel vs background agent execution and proactive monitoring

## Changes
- **Vue Router Component Reuse on Param Change**: Document the `watch(() => props.id)` pattern for handling component reuse when route params change
- **Navigation Guard Bypass**: Document the `skipNavGuard` ref pattern for bypassing `onBeforeRouteLeave` during programmatic navigation
- **Prefer Blocking Parallel Over Background Agents**: Guideline to use normal parallel Task calls when not doing other work
- **Monitor Background Agents Proactively**: Guideline to check agent progress without waiting for user to ask

## Test Plan
- [ ] Review CLAUDE.md for accuracy and clarity

---
Generated with [Claude Code](https://claude.ai/code)