### PR TITLE
fix: use browser fixture in e2e afterAll hook

### DIFF
--- a/tests/e2e/history.spec.ts
+++ b/tests/e2e/history.spec.ts
@@ -156,13 +156,16 @@ test.describe.serial('History Panel - Vue Event Sourcing', () => {
     await expect(panel(page)).not.toBeVisible();
   });
 
-  test.afterAll(async ({ page }) => {
+  test.afterAll(async ({ browser }) => {
     if (!applicationUrl) return;
+    const context = await browser.newContext();
+    const page = await context.newPage();
     await page.goto(applicationUrl);
     await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('input[placeholder="Company Name *"]', { timeout: 10000 });
     await page.click('button:has-text("Delete")');
     await page.locator('button:has-text("Delete")').last().click();
     await page.waitForURL('/');
+    await context.close();
   });
 });


### PR DESCRIPTION
## Summary
- Playwright does not support `page` and `context` fixtures in `test.afterAll` since they are per-test
- Changed `history.spec.ts` cleanup to use `browser.newContext()` instead, creating and closing a temporary context

## Test Plan
- [x] Run `npm run test:e2e:vue` — all 25 tests should pass (previously 1 failed)

---
Generated with [Claude Code](https://claude.ai/code)