### PR TITLE
chore: update next-env.d.ts auto-generated import path

### DIFF
--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Update Next.js auto-generated `next-env.d.ts` import path from `.next/types/` to `.next/dev/types/`
- Generated by Next.js 16 during build after dependency updates in #87

## Test Plan
- [x] Verify `npm run build` passes in `ui/`

---
Generated with [Claude Code](https://claude.ai/code)