### PR TITLE
ci: skip build steps for docs-only PRs

### DIFF
--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -13,23 +13,46 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for docs-only changes
+        id: docs-check
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            docs/**
+            **/*.md
+            **/*.mermaid
+            **/*.txt
+            **/*.png
+            **/*.jpg
+          files_ignore: |
+            package.json
+            **/package.json
 
       - name: Use Node.js from .node-version
+        if: steps.docs-check.outputs.only_changed == 'false'
         uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
 
       - name: Run Security Audit
+        if: steps.docs-check.outputs.only_changed == 'false'
         run: npm run audit:ci:all
 
       - name: Install npm packages
+        if: steps.docs-check.outputs.only_changed == 'false'
         run: npm run ci:all
 
       - name: Lint
+        if: steps.docs-check.outputs.only_changed == 'false'
         run: npm run lint:all
 
       - name: Build
+        if: steps.docs-check.outputs.only_changed == 'false'
         run: npm run build:all
 
       - name: Test
+        if: steps.docs-check.outputs.only_changed == 'false'
         run: npm run test:all


### PR DESCRIPTION
Adds smart detection to skip expensive build/test steps when PRs only modify documentation files.

## Changes
- Added `tj-actions/changed-files@v44` action to detect docs-only changes
- Configured to skip build steps when only these file types change:
  - Markdown (`**/*.md`)
  - Mermaid diagrams (`**/*.mermaid`)
  - Text files (`**/*.txt`)
  - Images (`**/*.png`, `**/*.jpg`)
  - Anything in `docs/` directory
- Excludes `package.json` from docs detection to ensure dependency changes always run full validation

## Benefits
- Faster CI for documentation PRs
- Reduced CI costs and resource usage
- Build chain still runs for any code changes
- Works correctly with dependency updates (package.json + package-lock.json triggers full validation)

## Testing
This PR itself will test the workflow since it only modifies `.github/workflows/verify-pr.yaml` (not a docs file), so it should run the full build chain.

---

Co-authored-by: GitHub Copilot