### PR TITLE
feat(hono+svelte): add snapshot-based application history and restore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ See [docs/DATABASE_ARCHITECTURE.md](docs/DATABASE_ARCHITECTURE.md) for per-imple
 
 ## Code Quality Requirements
 
-**Always complete the validation chain** after making code changes:
+**Always complete the full validation chain before committing**. Re-run the entire chain after every round of changes — not just the initial implementation. Fixing a bug introduced during review still requires the full chain.
 
 1. **Add tests** - Create or update tests for new functionality
 2. **Run tests** - Execute `npm test` to verify all tests pass
@@ -62,6 +62,7 @@ Prefer individual CRUD operations (`addStage`, `updateStage`, `removeStage`) ove
 - **React Router useBlocker**: Only works with `createBrowserRouter` + `RouterProvider`, not `<BrowserRouter>`
 - **SvelteKit SSR**: Add `export const ssr = false` in `src/routes/+layout.ts` for SPA mode with Playwright
 - **Svelte 5 bind:value**: Doesn't propagate with callback `onchange` — use local `$state` + `$effect`, call callback in `oninput`
+- **Shared E2E history tests**: `history.spec.ts` has a single `History Panel` block shared by Vue and Svelte; stacks without history use `--grep-invert 'History Panel'`
 
 ## Vue.js Patterns
 

--- a/hono-api/src/db/migrations/0000_optimal_sunfire.sql
+++ b/hono-api/src/db/migrations/0000_optimal_sunfire.sql
@@ -1,0 +1,50 @@
+CREATE SCHEMA "svelte_hono";
+--> statement-breakpoint
+CREATE TYPE "svelte_hono"."application_status" AS ENUM('applied', 'rejected', 'interviewing', 'given offer', 'accepted offer', 'declined offer', 'no offer');--> statement-breakpoint
+CREATE TYPE "svelte_hono"."company_category" AS ENUM('education', 'health', 'climate', 'ai', 'energy', 'finance', 'enterprise-software', 'consumer-tech', 'e-commerce', 'cybersecurity', 'gaming', 'media-entertainment', 'consulting', 'government', 'nonprofit', 'retail', 'restaurant', 'hospitality', 'other');--> statement-breakpoint
+CREATE TYPE "svelte_hono"."job_source" AS ENUM('recruiter', 'linkedin', 'indeed', 'friend', 'colleague', 'company-website', 'other');--> statement-breakpoint
+CREATE TABLE "svelte_hono"."application_history" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"application_id" uuid NOT NULL,
+	"sequence" integer NOT NULL,
+	"description" varchar(500) NOT NULL,
+	"snapshot" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "svelte_hono"."applications" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"company_name" varchar(200) NOT NULL,
+	"position_title" varchar(200) NOT NULL,
+	"date_applied" date NOT NULL,
+	"status" "svelte_hono"."application_status" DEFAULT 'applied' NOT NULL,
+	"company_url" text,
+	"job_posting_url" text,
+	"company_career_url" text,
+	"company_category" "svelte_hono"."company_category",
+	"skills_match" integer,
+	"job_source" "svelte_hono"."job_source",
+	"cover_letter_required" boolean,
+	"special_requirements" text,
+	"salary_min" integer,
+	"salary_max" integer,
+	"notes" text,
+	"offer_due_date" date,
+	"is_archived" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "svelte_hono"."interview_stages" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"application_id" uuid NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"order" integer NOT NULL,
+	"is_completed" boolean DEFAULT false NOT NULL,
+	"completed_date" date,
+	"notes" text,
+	"performance_rating" integer
+);
+--> statement-breakpoint
+ALTER TABLE "svelte_hono"."application_history" ADD CONSTRAINT "application_history_application_id_applications_id_fk" FOREIGN KEY ("application_id") REFERENCES "svelte_hono"."applications"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "svelte_hono"."interview_stages" ADD CONSTRAINT "interview_stages_application_id_applications_id_fk" FOREIGN KEY ("application_id") REFERENCES "svelte_hono"."applications"("id") ON DELETE cascade ON UPDATE no action;

--- a/hono-api/src/db/migrations/meta/0000_snapshot.json
+++ b/hono-api/src/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,355 @@
+{
+  "id": "cf391da5-bcf8-4c3d-a243-70de19db0543",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "svelte_hono.application_history": {
+      "name": "application_history",
+      "schema": "svelte_hono",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_history_application_id_applications_id_fk": {
+          "name": "application_history_application_id_applications_id_fk",
+          "tableFrom": "application_history",
+          "tableTo": "applications",
+          "schemaTo": "svelte_hono",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "svelte_hono.applications": {
+      "name": "applications",
+      "schema": "svelte_hono",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_title": {
+          "name": "position_title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_applied": {
+          "name": "date_applied",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "svelte_hono",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'applied'"
+        },
+        "company_url": {
+          "name": "company_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_posting_url": {
+          "name": "job_posting_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_career_url": {
+          "name": "company_career_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_category": {
+          "name": "company_category",
+          "type": "company_category",
+          "typeSchema": "svelte_hono",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills_match": {
+          "name": "skills_match",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_source": {
+          "name": "job_source",
+          "type": "job_source",
+          "typeSchema": "svelte_hono",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_letter_required": {
+          "name": "cover_letter_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "special_requirements": {
+          "name": "special_requirements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_min": {
+          "name": "salary_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_max": {
+          "name": "salary_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offer_due_date": {
+          "name": "offer_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "svelte_hono.interview_stages": {
+      "name": "interview_stages",
+      "schema": "svelte_hono",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performance_rating": {
+          "name": "performance_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_stages_application_id_applications_id_fk": {
+          "name": "interview_stages_application_id_applications_id_fk",
+          "tableFrom": "interview_stages",
+          "tableTo": "applications",
+          "schemaTo": "svelte_hono",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "svelte_hono.application_status": {
+      "name": "application_status",
+      "schema": "svelte_hono",
+      "values": [
+        "applied",
+        "rejected",
+        "interviewing",
+        "given offer",
+        "accepted offer",
+        "declined offer",
+        "no offer"
+      ]
+    },
+    "svelte_hono.company_category": {
+      "name": "company_category",
+      "schema": "svelte_hono",
+      "values": [
+        "education",
+        "health",
+        "climate",
+        "ai",
+        "energy",
+        "finance",
+        "enterprise-software",
+        "consumer-tech",
+        "e-commerce",
+        "cybersecurity",
+        "gaming",
+        "media-entertainment",
+        "consulting",
+        "government",
+        "nonprofit",
+        "retail",
+        "restaurant",
+        "hospitality",
+        "other"
+      ]
+    },
+    "svelte_hono.job_source": {
+      "name": "job_source",
+      "schema": "svelte_hono",
+      "values": [
+        "recruiter",
+        "linkedin",
+        "indeed",
+        "friend",
+        "colleague",
+        "company-website",
+        "other"
+      ]
+    }
+  },
+  "schemas": {
+    "svelte_hono": "svelte_hono"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/hono-api/src/db/migrations/meta/_journal.json
+++ b/hono-api/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1771187461569,
+      "tag": "0000_optimal_sunfire",
+      "breakpoints": true
+    }
+  ]
+}

--- a/hono-api/src/db/schema.ts
+++ b/hono-api/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { uuid, varchar, text, integer, boolean, date, timestamp, pgSchema } from 'drizzle-orm/pg-core';
+import { uuid, varchar, text, integer, boolean, date, timestamp, jsonb, pgSchema } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 
 // Define the svelte_hono schema
@@ -84,9 +84,22 @@ export const interviewStages = svelteHonoSchema.table('interview_stages', {
   performanceRating: integer('performance_rating'),
 });
 
+// Application History (snapshot-based version tracking)
+export const applicationHistory = svelteHonoSchema.table('application_history', {
+  id: uuid('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  applicationId: uuid('application_id')
+    .notNull()
+    .references(() => applications.id, { onDelete: 'cascade' }),
+  sequence: integer('sequence').notNull(),
+  description: varchar('description', { length: 500 }).notNull(),
+  snapshot: jsonb('snapshot').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
 // Relations
 export const applicationsRelations = relations(applications, ({ many }) => ({
   interviewStages: many(interviewStages),
+  history: many(applicationHistory),
 }));
 
 export const interviewStagesRelations = relations(interviewStages, ({ one }) => ({
@@ -96,11 +109,20 @@ export const interviewStagesRelations = relations(interviewStages, ({ one }) => 
   }),
 }));
 
+export const applicationHistoryRelations = relations(applicationHistory, ({ one }) => ({
+  application: one(applications, {
+    fields: [applicationHistory.applicationId],
+    references: [applications.id],
+  }),
+}));
+
 // Types
 export type Application = typeof applications.$inferSelect;
 export type NewApplication = typeof applications.$inferInsert;
 export type InterviewStage = typeof interviewStages.$inferSelect;
 export type NewInterviewStage = typeof interviewStages.$inferInsert;
+export type ApplicationHistoryEntry = typeof applicationHistory.$inferSelect;
+export type NewApplicationHistoryEntry = typeof applicationHistory.$inferInsert;
 export type ApplicationStatus = (typeof applicationStatusEnum.enumValues)[number];
 export type CompanyCategory = (typeof companyCategoryEnum.enumValues)[number];
 export type JobSource = (typeof jobSourceEnum.enumValues)[number];

--- a/hono-api/src/routes/applications.ts
+++ b/hono-api/src/routes/applications.ts
@@ -7,9 +7,11 @@ import {
   ListApplicationsQuerySchema,
   CreateInterviewStageSchema,
   UpdateInterviewStageSchema,
+  RestoreRequestSchema,
 } from '../types/api.js';
 import * as applicationService from '../services/application.service.js';
 import * as interviewStageService from '../services/interview-stage.service.js';
+import * as historyService from '../services/history.service.js';
 
 const applications = new Hono();
 
@@ -127,6 +129,53 @@ applications.post('/:id/restore', zValidator('param', z.object({ id: z.string().
     return c.json({ code: 'internal_error', message: 'An unexpected error occurred' }, 500);
   }
 });
+
+// Get application history
+applications.get(
+  '/:id/history',
+  zValidator('param', z.object({ id: z.string().uuid() })),
+  zValidator(
+    'query',
+    z.object({
+      page: z.coerce.number().int().min(1).default(1),
+      limit: z.coerce.number().int().min(1).max(100).default(50),
+    })
+  ),
+  async (c) => {
+    try {
+      const { id } = c.req.valid('param');
+      const { page, limit } = c.req.valid('query');
+      const result = await historyService.listHistory(id, page, limit);
+      return c.json(result);
+    } catch (error) {
+      console.error('Error listing application history:', error);
+      return c.json({ code: 'internal_error', message: 'An unexpected error occurred' }, 500);
+    }
+  }
+);
+
+// Restore application to historical version
+applications.post(
+  '/:id/history/restore',
+  zValidator('param', z.object({ id: z.string().uuid() })),
+  zValidator('json', RestoreRequestSchema),
+  async (c) => {
+    try {
+      const { id } = c.req.valid('param');
+      const { sequence } = c.req.valid('json');
+      const result = await historyService.restoreToVersion(id, sequence);
+
+      if (!result) {
+        return c.json({ code: 'not_found', message: 'History entry not found' }, 404);
+      }
+
+      return c.json(result);
+    } catch (error) {
+      console.error('Error restoring application version:', error);
+      return c.json({ code: 'internal_error', message: 'An unexpected error occurred' }, 500);
+    }
+  }
+);
 
 // Create interview stage
 applications.post(

--- a/hono-api/src/services/application.service.ts
+++ b/hono-api/src/services/application.service.ts
@@ -1,6 +1,6 @@
 import { eq, and, sql, asc, desc, gte, inArray } from 'drizzle-orm';
 import { db } from '../db/client.js';
-import { applications, interviewStages, type Application, type InterviewStage } from '../db/schema.js';
+import { applications, interviewStages, type Application } from '../db/schema.js';
 import type {
   CreateApplicationInput,
   UpdateApplicationInput,
@@ -8,56 +8,27 @@ import type {
   ApplicationResponse,
   PaginatedApplicationsResponse,
 } from '../types/api.js';
+import { toApplicationResponse } from './shared.js';
+import { recordHistory, buildDescription } from './history.service.js';
 
-// Helper to format date for response
-function formatDate(date: string | Date | null): string | null {
-  if (!date) return null;
-  if (typeof date === 'string') return date;
-  return date.toISOString().split('T')[0];
-}
-
-// Helper to format datetime for response
-function formatDateTime(date: Date | null): string {
-  if (!date) return new Date().toISOString();
-  return date.toISOString();
-}
-
-// Transform DB application to API response
-function toApplicationResponse(app: Application, stages: InterviewStage[]): ApplicationResponse {
-  return {
-    id: app.id,
-    companyName: app.companyName,
-    positionTitle: app.positionTitle,
-    dateApplied: formatDate(app.dateApplied) || '',
-    status: app.status,
-    createdAt: formatDateTime(app.createdAt),
-    updatedAt: formatDateTime(app.updatedAt),
-    companyUrl: app.companyUrl,
-    jobPostingUrl: app.jobPostingUrl,
-    companyCareerUrl: app.companyCareerUrl,
-    companyCategory: app.companyCategory,
-    skillsMatch: app.skillsMatch,
-    jobSource: app.jobSource,
-    coverLetterRequired: app.coverLetterRequired,
-    specialRequirements: app.specialRequirements,
-    salaryMin: app.salaryMin,
-    salaryMax: app.salaryMax,
-    notes: app.notes,
-    offerDueDate: formatDate(app.offerDueDate),
-    isArchived: app.isArchived,
-    interviewStages: stages
-      .sort((a, b) => a.order - b.order)
-      .map((s) => ({
-        id: s.id,
-        name: s.name,
-        order: s.order,
-        isCompleted: s.isCompleted,
-        completedDate: formatDate(s.completedDate),
-        notes: s.notes,
-        performanceRating: s.performanceRating,
-      })),
-  };
-}
+const FIELD_LABELS_MAP: Record<string, string> = {
+  companyName: 'Company Name',
+  positionTitle: 'Position Title',
+  dateApplied: 'Date Applied',
+  status: 'Status',
+  companyUrl: 'Company URL',
+  jobPostingUrl: 'Job Posting URL',
+  companyCareerUrl: 'Career Page URL',
+  companyCategory: 'Company Category',
+  skillsMatch: 'Skills Match',
+  jobSource: 'Job Source',
+  coverLetterRequired: 'Cover Letter Required',
+  specialRequirements: 'Special Requirements',
+  salaryMin: 'Min Salary',
+  salaryMax: 'Max Salary',
+  notes: 'Notes',
+  offerDueDate: 'Offer Due Date',
+};
 
 export async function listApplications(query: ListApplicationsQuery): Promise<PaginatedApplicationsResponse> {
   const { status, companyCategory, jobSource, skillsMatchMin, includeArchived, sortBy, sortDir, page, limit } = query;
@@ -158,6 +129,8 @@ export async function createApplication(input: CreateApplicationInput): Promise<
     })
     .returning();
 
+  await recordHistory(app.id, buildDescription('create', `${app.companyName} - ${app.positionTitle}`));
+
   return toApplicationResponse(app, []);
 }
 
@@ -197,10 +170,20 @@ export async function updateApplication(id: string, input: UpdateApplicationInpu
     where: eq(interviewStages.applicationId, id),
   });
 
+  // Record history after update (snapshot captures post-mutation state)
+  const changedFields = Object.keys(input)
+    .filter((key) => key in FIELD_LABELS_MAP)
+    .map((key) => FIELD_LABELS_MAP[key]);
+  if (changedFields.length > 0) {
+    await recordHistory(id, buildDescription('update', changedFields.join(', ')));
+  }
+
   return toApplicationResponse(updated, stages);
 }
 
 export async function deleteApplication(id: string): Promise<boolean> {
+  await recordHistory(id, buildDescription('delete'));
+
   const result = await db.delete(applications).where(eq(applications.id, id)).returning({ id: applications.id });
   return result.length > 0;
 }
@@ -218,6 +201,8 @@ export async function archiveApplication(id: string): Promise<ApplicationRespons
     where: eq(interviewStages.applicationId, id),
   });
 
+  await recordHistory(id, buildDescription('archive'));
+
   return toApplicationResponse(updated, stages);
 }
 
@@ -233,6 +218,8 @@ export async function restoreApplication(id: string): Promise<ApplicationRespons
   const stages = await db.query.interviewStages.findMany({
     where: eq(interviewStages.applicationId, id),
   });
+
+  await recordHistory(id, buildDescription('restore'));
 
   return toApplicationResponse(updated, stages);
 }

--- a/hono-api/src/services/history.service.ts
+++ b/hono-api/src/services/history.service.ts
@@ -1,0 +1,234 @@
+import { eq, and, desc, sql } from 'drizzle-orm';
+import { db } from '../db/client.js';
+import { applicationHistory, applications, interviewStages } from '../db/schema.js';
+import { toApplicationResponse } from './shared.js';
+import type { ApplicationResponse, HistoryEntryResponse, PaginatedHistoryResponse } from '../types/api.js';
+
+interface FieldChange {
+  field: string;
+  label: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  companyName: 'Company Name',
+  positionTitle: 'Position Title',
+  dateApplied: 'Date Applied',
+  status: 'Status',
+  companyUrl: 'Company URL',
+  jobPostingUrl: 'Job Posting URL',
+  companyCareerUrl: 'Career Page URL',
+  companyCategory: 'Company Category',
+  skillsMatch: 'Skills Match',
+  jobSource: 'Job Source',
+  coverLetterRequired: 'Cover Letter Required',
+  specialRequirements: 'Special Requirements',
+  salaryMin: 'Min Salary',
+  salaryMax: 'Max Salary',
+  notes: 'Notes',
+  offerDueDate: 'Offer Due Date',
+  isArchived: 'Archived',
+};
+
+export async function captureSnapshot(applicationId: string): Promise<ApplicationResponse | null> {
+  const app = await db.query.applications.findFirst({
+    where: eq(applications.id, applicationId),
+    with: { interviewStages: true },
+  });
+
+  if (!app) return null;
+  return toApplicationResponse(app, app.interviewStages);
+}
+
+export async function getNextSequence(applicationId: string): Promise<number> {
+  const result = await db
+    .select({ maxSeq: sql<number>`coalesce(max(${applicationHistory.sequence}), 0)` })
+    .from(applicationHistory)
+    .where(eq(applicationHistory.applicationId, applicationId));
+
+  return Number(result[0]?.maxSeq ?? 0) + 1;
+}
+
+export async function recordHistory(applicationId: string, description: string): Promise<void> {
+  const snapshot = await captureSnapshot(applicationId);
+  if (!snapshot) return;
+
+  const sequence = await getNextSequence(applicationId);
+
+  await db.insert(applicationHistory).values({
+    applicationId,
+    sequence,
+    description,
+    snapshot,
+  });
+}
+
+export async function listHistory(
+  applicationId: string,
+  page: number = 1,
+  limit: number = 50
+): Promise<PaginatedHistoryResponse> {
+  // Get total count
+  const countResult = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(applicationHistory)
+    .where(eq(applicationHistory.applicationId, applicationId));
+
+  const total = Number(countResult[0]?.count || 0);
+
+  // Get paginated entries (newest first)
+  const offset = (page - 1) * limit;
+  const rows = await db
+    .select()
+    .from(applicationHistory)
+    .where(eq(applicationHistory.applicationId, applicationId))
+    .orderBy(desc(applicationHistory.sequence))
+    .limit(limit)
+    .offset(offset);
+
+  // Build entries with diffs
+  // Each entry's snapshot = state AFTER that change.
+  // To show what changed, compare the previous entry's snapshot (before) to this entry's snapshot (after).
+  // Entries are sorted newest first: [newest, ..., oldest]
+  const entries: HistoryEntryResponse[] = rows.map((row, index) => {
+    const thisSnapshot = row.snapshot as ApplicationResponse;
+    let changes: FieldChange[] = [];
+
+    // The "before" state is the next item in the array (older entry), or empty for the first-ever entry
+    const olderRow = rows[index + 1];
+    if (olderRow) {
+      const olderSnapshot = olderRow.snapshot as ApplicationResponse;
+      changes = computeFieldDiffs(olderSnapshot, thisSnapshot);
+    }
+    // For the oldest entry (creation), changes stays empty — no "before" to compare against
+
+    return {
+      id: row.id,
+      sequence: row.sequence,
+      description: row.description,
+      changes,
+      createdAt: row.createdAt.toISOString(),
+    };
+  });
+
+  return { entries, total, page, limit };
+}
+
+export async function restoreToVersion(
+  applicationId: string,
+  targetSequence: number
+): Promise<ApplicationResponse | null> {
+  // Find the history entry
+  const entry = await db.query.applicationHistory.findFirst({
+    where: and(
+      eq(applicationHistory.applicationId, applicationId),
+      eq(applicationHistory.sequence, targetSequence)
+    ),
+  });
+
+  if (!entry) return null;
+
+  const snapshot = entry.snapshot as ApplicationResponse;
+
+  // Overwrite the applications row with snapshot values
+  await db
+    .update(applications)
+    .set({
+      companyName: snapshot.companyName,
+      positionTitle: snapshot.positionTitle,
+      dateApplied: snapshot.dateApplied,
+      status: snapshot.status,
+      companyUrl: snapshot.companyUrl,
+      jobPostingUrl: snapshot.jobPostingUrl,
+      companyCareerUrl: snapshot.companyCareerUrl,
+      companyCategory: snapshot.companyCategory,
+      skillsMatch: snapshot.skillsMatch,
+      jobSource: snapshot.jobSource,
+      coverLetterRequired: snapshot.coverLetterRequired,
+      specialRequirements: snapshot.specialRequirements,
+      salaryMin: snapshot.salaryMin,
+      salaryMax: snapshot.salaryMax,
+      notes: snapshot.notes,
+      offerDueDate: snapshot.offerDueDate,
+      isArchived: snapshot.isArchived,
+      updatedAt: new Date(),
+    })
+    .where(eq(applications.id, applicationId));
+
+  // Delete all current interview stages for this app
+  await db.delete(interviewStages).where(eq(interviewStages.applicationId, applicationId));
+
+  // Re-insert stages from snapshot
+  if (snapshot.interviewStages && snapshot.interviewStages.length > 0) {
+    await db.insert(interviewStages).values(
+      snapshot.interviewStages.map((s) => ({
+        applicationId,
+        name: s.name,
+        order: s.order,
+        isCompleted: s.isCompleted,
+        completedDate: s.completedDate || null,
+        notes: s.notes,
+        performanceRating: s.performanceRating,
+      }))
+    );
+  }
+
+  // Record history after restore (snapshot captures post-restore state)
+  await recordHistory(applicationId, buildDescription('restore_version', String(targetSequence)));
+
+  // Return the restored state
+  return captureSnapshot(applicationId);
+}
+
+export function computeFieldDiffs(before: ApplicationResponse, after: ApplicationResponse): FieldChange[] {
+  const changes: FieldChange[] = [];
+
+  for (const [field, label] of Object.entries(FIELD_LABELS)) {
+    const oldValue = (before as Record<string, unknown>)[field];
+    const newValue = (after as Record<string, unknown>)[field];
+
+    if (JSON.stringify(oldValue) !== JSON.stringify(newValue)) {
+      changes.push({ field, label, oldValue, newValue });
+    }
+  }
+
+  // Compare interview stages
+  const oldStages = JSON.stringify(before.interviewStages);
+  const newStages = JSON.stringify(after.interviewStages);
+  if (oldStages !== newStages) {
+    changes.push({
+      field: 'interviewStages',
+      label: 'Interview Stages',
+      oldValue: before.interviewStages,
+      newValue: after.interviewStages,
+    });
+  }
+
+  return changes;
+}
+
+export function buildDescription(action: string, details?: string): string {
+  switch (action) {
+    case 'create':
+      return `Created application ${details || ''}`.trim();
+    case 'update':
+      return `Updated ${details || ''}`.trim();
+    case 'delete':
+      return 'Deleted application';
+    case 'archive':
+      return 'Archived application';
+    case 'restore':
+      return 'Restored from archive';
+    case 'restore_version':
+      return `Restored to version ${details}`;
+    case 'stage_add':
+      return `Added interview stage "${details}"`;
+    case 'stage_update':
+      return `Updated interview stage "${details}"`;
+    case 'stage_delete':
+      return `Removed interview stage "${details}"`;
+    default:
+      return details || action;
+  }
+}

--- a/hono-api/src/services/interview-stage.service.ts
+++ b/hono-api/src/services/interview-stage.service.ts
@@ -2,13 +2,8 @@ import { eq, and } from 'drizzle-orm';
 import { db } from '../db/client.js';
 import { applications, interviewStages, type InterviewStage } from '../db/schema.js';
 import type { CreateInterviewStageInput, UpdateInterviewStageInput, InterviewStageResponse } from '../types/api.js';
-
-// Helper to format date for response
-function formatDate(date: string | Date | null): string | null {
-  if (!date) return null;
-  if (typeof date === 'string') return date;
-  return date.toISOString().split('T')[0];
-}
+import { formatDate } from './shared.js';
+import { recordHistory, buildDescription } from './history.service.js';
 
 // Transform DB stage to API response
 function toStageResponse(stage: InterviewStage): InterviewStageResponse {
@@ -50,6 +45,8 @@ export async function createInterviewStage(
   // Update application's updatedAt
   await db.update(applications).set({ updatedAt: new Date() }).where(eq(applications.id, applicationId));
 
+  await recordHistory(applicationId, buildDescription('stage_add', input.name));
+
   return toStageResponse(stage);
 }
 
@@ -84,10 +81,21 @@ export async function updateInterviewStage(
   // Update application's updatedAt
   await db.update(applications).set({ updatedAt: new Date() }).where(eq(applications.id, applicationId));
 
+  await recordHistory(applicationId, buildDescription('stage_update', existing.name));
+
   return toStageResponse(updated);
 }
 
 export async function deleteInterviewStage(applicationId: string, stageId: string): Promise<boolean> {
+  // Query stage first to get its name for history
+  const stage = await db.query.interviewStages.findFirst({
+    where: and(eq(interviewStages.id, stageId), eq(interviewStages.applicationId, applicationId)),
+  });
+
+  if (stage) {
+    await recordHistory(applicationId, buildDescription('stage_delete', stage.name));
+  }
+
   const result = await db
     .delete(interviewStages)
     .where(and(eq(interviewStages.id, stageId), eq(interviewStages.applicationId, applicationId)))

--- a/hono-api/src/services/shared.ts
+++ b/hono-api/src/services/shared.ts
@@ -1,0 +1,52 @@
+import type { Application, InterviewStage } from '../db/schema.js';
+import type { ApplicationResponse } from '../types/api.js';
+
+// Helper to format date for response
+export function formatDate(date: string | Date | null): string | null {
+  if (!date) return null;
+  if (typeof date === 'string') return date;
+  return date.toISOString().split('T')[0];
+}
+
+// Helper to format datetime for response
+export function formatDateTime(date: Date | null): string {
+  if (!date) return new Date().toISOString();
+  return date.toISOString();
+}
+
+// Transform DB application to API response
+export function toApplicationResponse(app: Application, stages: InterviewStage[]): ApplicationResponse {
+  return {
+    id: app.id,
+    companyName: app.companyName,
+    positionTitle: app.positionTitle,
+    dateApplied: formatDate(app.dateApplied) || '',
+    status: app.status,
+    createdAt: formatDateTime(app.createdAt),
+    updatedAt: formatDateTime(app.updatedAt),
+    companyUrl: app.companyUrl,
+    jobPostingUrl: app.jobPostingUrl,
+    companyCareerUrl: app.companyCareerUrl,
+    companyCategory: app.companyCategory,
+    skillsMatch: app.skillsMatch,
+    jobSource: app.jobSource,
+    coverLetterRequired: app.coverLetterRequired,
+    specialRequirements: app.specialRequirements,
+    salaryMin: app.salaryMin,
+    salaryMax: app.salaryMax,
+    notes: app.notes,
+    offerDueDate: formatDate(app.offerDueDate),
+    isArchived: app.isArchived,
+    interviewStages: stages
+      .sort((a, b) => a.order - b.order)
+      .map((s) => ({
+        id: s.id,
+        name: s.name,
+        order: s.order,
+        isCompleted: s.isCompleted,
+        completedDate: formatDate(s.completedDate),
+        notes: s.notes,
+        performanceRating: s.performanceRating,
+      })),
+  };
+}

--- a/hono-api/src/types/api.ts
+++ b/hono-api/src/types/api.ts
@@ -167,6 +167,36 @@ export const PaginatedApplicationsSchema = z.object({
 });
 export type PaginatedApplicationsResponse = z.infer<typeof PaginatedApplicationsSchema>;
 
+// History types
+export const FieldChangeSchema = z.object({
+  field: z.string(),
+  label: z.string(),
+  oldValue: z.unknown(),
+  newValue: z.unknown(),
+});
+export type FieldChange = z.infer<typeof FieldChangeSchema>;
+
+export const HistoryEntrySchema = z.object({
+  id: z.string().uuid(),
+  sequence: z.number().int(),
+  description: z.string(),
+  changes: z.array(FieldChangeSchema),
+  createdAt: z.string(),
+});
+export type HistoryEntryResponse = z.infer<typeof HistoryEntrySchema>;
+
+export const PaginatedHistorySchema = z.object({
+  entries: z.array(HistoryEntrySchema),
+  total: z.number().int(),
+  page: z.number().int(),
+  limit: z.number().int(),
+});
+export type PaginatedHistoryResponse = z.infer<typeof PaginatedHistorySchema>;
+
+export const RestoreRequestSchema = z.object({
+  sequence: z.number().int().min(1),
+});
+
 // Error response
 export const ErrorResponseSchema = z.object({
   code: z.enum(['validation_error', 'not_found', 'internal_error']),

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "test:api:opaque": "npx -y jest --config tests/jest.config.js --testPathPatterns=tests/api",
     "test:e2e": "TEST_UI_PORT=3000 PLAYWRIGHT_HTML_OPEN=never npx -y playwright test --grep-invert 'History Panel'",
     "test:e2e:vue": "TEST_UI_PORT=3020 PLAYWRIGHT_HTML_OPEN=never npx -y playwright test",
-    "test:e2e:svelte": "TEST_UI_PORT=3030 PLAYWRIGHT_HTML_OPEN=never npx -y playwright test --grep-invert 'History Panel'",
+    "test:e2e:svelte": "TEST_UI_PORT=3030 PLAYWRIGHT_HTML_OPEN=never npx -y playwright test",
     "test:e2e:react-koa": "TEST_UI_PORT=3010 PLAYWRIGHT_HTML_OPEN=never npx -y playwright test --grep-invert 'History Panel'",
     "test:e2e:all": "npm run test:e2e && npm run test:e2e:vue && npm run test:e2e:svelte && npm run test:e2e:react-koa",
     "test:e2e:ui": "npx -y playwright test --ui",

--- a/specs/006-history-snapshots-svelte/plan.md
+++ b/specs/006-history-snapshots-svelte/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Application History & Restore (Svelte + Hono)
+
+**Branch**: `006-history-snapshots-svelte` | **Date**: 2026-02-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/006-history-snapshots-svelte/spec.md`
+
+## Summary
+
+Add snapshot-based application history and restore to the Hono + Drizzle backend and SvelteKit frontend. Each mutation captures the full application state as a JSONB snapshot. Field-level diffs are computed at read time by comparing adjacent snapshots. Users can view history in a sliding panel and restore to any previous version.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict mode)
+**Primary Dependencies**: Hono, Drizzle ORM, Zod, SvelteKit, Svelte 5
+**Storage**: PostgreSQL 18, `svelte_hono` schema
+**Testing**: Playwright (E2E), Vitest (unit)
+**No new dependencies required**
+
+## Architecture
+
+### Snapshot-Based History (vs. Vue-Nuxt Event Sourcing)
+
+The vue-nuxt implementation uses Immer patches for deterministic undo/redo. This implementation takes a simpler approach:
+
+| Aspect | Vue-Nuxt (Event Sourcing) | Svelte-Hono (Snapshots) |
+|--------|---------------------------|-------------------------|
+| Storage | Patches + inverse patches | Full state snapshots |
+| Diffs | Stored as `FieldChange[]` | Computed at read time |
+| Restore | Replay patches from nearest snapshot | Copy snapshot to DB |
+| Undo/Redo | Yes (Ctrl+Z/Shift+Z) | No |
+| Complexity | High (Immer, Pinia, cursor) | Low (service wrapper) |
+
+### Database
+
+New table `application_history` in `svelte_hono` schema:
+
+```
+id              uuid PK
+application_id  uuid FK → applications(id) CASCADE
+sequence        integer (monotonic per application)
+description     varchar(500)
+snapshot        jsonb (full ApplicationResponse)
+created_at      timestamptz
+```
+
+### Service Layer Pattern
+
+```
+mutation request
+  → recordHistory(appId, description)  // captures current state as snapshot
+  → execute mutation
+  → return response
+```
+
+For `createApplication`: record **after** (no "before" state exists).
+For all other mutations: record **before** (snapshot = pre-change state).
+
+### API Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/applications/:id/history?page=1&limit=50` | List history entries with diffs |
+| POST | `/applications/:id/history/restore` | Restore to `{ sequence: N }` |
+
+### Frontend
+
+- `HistoryPanel.svelte`: Fixed right-side sliding panel (w-96)
+- `FieldDiff.svelte`: Old/new value display component
+- Integration via "History" button in `ApplicationEdit.svelte`
+
+## Files to Create/Modify
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `hono-api/src/services/shared.ts` | Extracted `toApplicationResponse`, `formatDate`, `formatDateTime` |
+| `hono-api/src/services/history.service.ts` | Core history logic (record, list, restore, diff) |
+| `svelte-ui/src/lib/components/HistoryPanel.svelte` | History timeline panel |
+| `svelte-ui/src/lib/components/FieldDiff.svelte` | Field change display |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `hono-api/src/db/schema.ts` | Add `applicationHistory` table + relations |
+| `hono-api/src/types/api.ts` | Add history Zod schemas |
+| `hono-api/src/routes/applications.ts` | Add GET history + POST restore routes |
+| `hono-api/src/services/application.service.ts` | Add `recordHistory` calls, import from shared |
+| `hono-api/src/services/interview-stage.service.ts` | Add `recordHistory` calls, import from shared |
+| `svelte-ui/src/lib/types/index.ts` | Add history types |
+| `svelte-ui/src/lib/stores/api.ts` | Add history API methods |
+| `svelte-ui/src/lib/components/ApplicationEdit.svelte` | Add History button + panel |
+| `tests/e2e/history.spec.ts` | Add Svelte history test block |
+| `package.json` | Update e2e grep pattern |
+
+## Execution Strategy
+
+**Phase 1** (sequential): Schema + migration + shared utils extraction
+**Phase 2** (parallel agents):
+- Backend agent: history service, wiring into existing services, API routes
+- Frontend agent: types, API client, HistoryPanel, FieldDiff, ApplicationEdit integration
+**Phase 3** (sequential): Validation chain (build, lint, typecheck)
+**Phase 4**: E2E tests
+
+## Verification
+
+1. `cd hono-api && npm run build && npm run lint`
+2. `cd svelte-ui && npm run build && npm run check && npm run lint`
+3. `npm run test:e2e:svelte` — existing 13 shared tests pass
+4. `npm run test:e2e:svelte` — new history tests pass
+5. Manual: create app → edit → open history → see entries → restore → verify

--- a/specs/006-history-snapshots-svelte/spec.md
+++ b/specs/006-history-snapshots-svelte/spec.md
@@ -1,0 +1,103 @@
+# Feature Specification: Application History & Restore (Svelte + Hono)
+
+**Feature Branch**: `006-history-snapshots-svelte`
+**Created**: 2026-02-15
+**Status**: Draft
+**Input**: Add version history and restore functionality to the Svelte+Hono stack, using a snapshot-based approach idiomatic to Drizzle's service-layer patterns.
+
+- [Context](#context)
+- [User Scenarios & Testing](#user-scenarios--testing)
+  - [User Story 1 - View Application History (Priority: P1)](#user-story-1---view-application-history-priority-p1)
+  - [User Story 2 - View Field-Level Changes (Priority: P1)](#user-story-2---view-field-level-changes-priority-p1)
+  - [User Story 3 - Restore to Previous Version (Priority: P1)](#user-story-3---restore-to-previous-version-priority-p1)
+- [Requirements](#requirements)
+  - [Functional Requirements](#functional-requirements)
+  - [Technical Requirements](#technical-requirements)
+- [Success Criteria](#success-criteria)
+
+## Context
+
+The vue-nuxt implementation already has event sourcing with Immer patches, undo/redo, and a history panel. This spec covers adding a **simpler, snapshot-based** history feature to the Svelte+Hono stack as a prototype for the remaining three implementations. Each stack will use an idiomatic approach:
+
+- **Hono + Drizzle (this spec)**: Service-layer `withHistory` wrapper using Drizzle transactions
+- **Express + Prisma (future)**: Prisma Client Extensions / middleware
+- **Koa + Raw SQL (future)**: PostgreSQL triggers + history table
+
+**Scope**: History panel + restore only. No undo/redo keyboard shortcuts.
+
+## User Scenarios & Testing
+
+### User Story 1 - View Application History (Priority: P1)
+
+As a user, I want to see a timeline of all changes made to an application so that I can understand its history.
+
+**Why this priority**: Core functionality - users need to see what changed and when.
+
+**Acceptance Scenarios**:
+
+1. **Given** I have created an application, **When** I click the "History" button on the edit page, **Then** a side panel opens showing a timeline with a "Created application" entry marked as "(current)".
+2. **Given** I have edited an application multiple times, **When** I open the history panel, **Then** I see all changes listed newest-first with relative timestamps (e.g., "5m ago", "2h ago").
+3. **Given** I have the history panel open, **When** I click the close button, **Then** the panel closes.
+4. **Given** an application has no history entries, **When** I open the history panel, **Then** I see an appropriate empty state message.
+
+---
+
+### User Story 2 - View Field-Level Changes (Priority: P1)
+
+As a user, I want to see exactly which fields changed in each history entry so that I can understand what was modified.
+
+**Why this priority**: Without diffs, history is just a list of timestamps - users need to see what actually changed.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am viewing the history panel, **When** I click on a history entry, **Then** it expands to show field-level changes (old value struck through in red, new value in green).
+2. **Given** I updated the company name from "Acme" to "Acme Corp", **When** I expand that history entry, **Then** I see "Company Name: ~~Acme~~ Acme Corp".
+3. **Given** I added an interview stage, **When** I expand that history entry, **Then** I see the interview stages change (e.g., "Interview Stages: 0 stages -> 1 stage").
+4. **Given** a history entry has no detected field changes, **When** I expand it, **Then** I see "No field changes recorded".
+
+---
+
+### User Story 3 - Restore to Previous Version (Priority: P1)
+
+As a user, I want to restore an application to a previous version so that I can undo unwanted changes.
+
+**Why this priority**: The primary value of history - being able to go back to a known good state.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am viewing a history entry that is not the current version, **When** I click "Restore to this point", **Then** the application is restored to that version's state and the form updates.
+2. **Given** I restore to a previous version, **When** I view the history panel, **Then** I see a new "Restored to version N" entry as the newest entry.
+3. **Given** I restore to a version that had different interview stages, **When** I view the application, **Then** the interview stages match the restored version.
+4. **Given** I am viewing the newest (current) history entry, **Then** the "Restore to this point" button is not shown (already at current version).
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+1. **History Recording**: Automatically record a snapshot of application state on every mutation (create, update, delete, archive, restore, stage CRUD)
+2. **History Panel**: Sliding side panel on the application edit page showing change timeline
+3. **Field-Level Diffs**: Computed at read time by comparing adjacent snapshots
+4. **Restore**: Copy any historical snapshot back to the application table, replacing current state
+5. **Cascade Cleanup**: History entries deleted when parent application is deleted
+
+### Technical Requirements
+
+1. **Database**: New `application_history` table in `svelte_hono` schema (Drizzle)
+2. **Snapshot Format**: Full `ApplicationResponse` (including `interviewStages[]`) stored as JSONB
+3. **Sequence Numbers**: Monotonically increasing per application for ordering
+4. **Service Layer**: `withHistory` pattern - capture state before/after mutations at the service layer
+5. **API**: RESTful endpoints for listing history and restoring versions
+6. **No New Dependencies**: Uses existing Drizzle, Hono, Zod, and SvelteKit tooling
+
+## Success Criteria
+
+- [ ] Every application mutation (create, update, archive, restore, stage CRUD) creates a history entry
+- [ ] History panel shows all entries with correct descriptions and relative timestamps
+- [ ] Expanding an entry shows accurate field-level diffs
+- [ ] Restoring to a version correctly reverts application fields and interview stages
+- [ ] "Restored to version N" entry appears after restore
+- [ ] Existing shared E2E tests (13 tests) continue to pass
+- [ ] New history-specific E2E tests pass
+- [ ] Build and lint pass for both hono-api and svelte-ui

--- a/specs/006-history-snapshots-svelte/tasks.md
+++ b/specs/006-history-snapshots-svelte/tasks.md
@@ -1,0 +1,103 @@
+---
+description: "Task list for Application History & Restore (Svelte + Hono)"
+---
+
+# Tasks: Application History & Restore (Svelte + Hono)
+
+**Input**: Design documents from `/specs/006-history-snapshots-svelte/`
+**Specification**: [spec.md](spec.md) (3 user stories, all P1)
+**Project**: Hono + Drizzle (backend), SvelteKit + Svelte 5 (frontend)
+
+**Organization**: Tasks grouped by phase. Backend and frontend phases can run in parallel.
+
+## Dependencies & Execution Order
+
+- Phase 1 (Foundation) is blocking — must complete before Phase 2
+- Phase 2A (Backend) and Phase 2B (Frontend) can run in parallel
+- Phase 3 (Integration) requires both 2A and 2B complete
+- Phase 4 (E2E Tests) requires Phase 3 complete
+
+---
+
+## Phase 1: Foundation (Sequential)
+
+**Purpose**: Database schema and shared utilities
+
+- [ ] T001 Add `applicationHistory` table to `hono-api/src/db/schema.ts` with relations and type exports
+- [ ] T002 Run `drizzle-kit generate` and `drizzle-kit push` to create and apply migration
+- [ ] T003 Extract `toApplicationResponse`, `formatDate`, `formatDateTime` to `hono-api/src/services/shared.ts`
+- [ ] T004 Update `application.service.ts` and `interview-stage.service.ts` to import from shared
+
+**Checkpoint**: Schema deployed, shared utils extracted, existing build passes
+
+---
+
+## Phase 2A: Backend (Parallelizable with 2B)
+
+**Purpose**: History service, wiring, and API routes
+
+- [ ] T005 Create `hono-api/src/services/history.service.ts` with `captureSnapshot`, `recordHistory`, `getNextSequence`
+- [ ] T006 Add `listHistory(appId, page, limit)` with field-level diff computation
+- [ ] T007 Add `restoreToVersion(appId, targetSequence)` with snapshot restore logic
+- [ ] T008 Add `computeFieldDiffs(before, after)` and `buildDescription(action, details?)` helpers
+- [ ] T009 Wire `recordHistory` into `application.service.ts` (create, update, delete, archive, restore)
+- [ ] T010 Wire `recordHistory` into `interview-stage.service.ts` (create, update, delete)
+- [ ] T011 Add `FieldChangeSchema`, `HistoryEntrySchema`, `PaginatedHistorySchema` to `hono-api/src/types/api.ts`
+- [ ] T012 Add `GET /:id/history` and `POST /:id/history/restore` routes to `hono-api/src/routes/applications.ts`
+
+**Checkpoint**: Backend compiles, history API functional
+
+---
+
+## Phase 2B: Frontend (Parallelizable with 2A)
+
+**Purpose**: UI components and integration
+
+- [ ] T013 Add `FieldChange`, `HistoryEntry`, `PaginatedHistoryResponse` types to `svelte-ui/src/lib/types/index.ts`
+- [ ] T014 Add `getHistory` and `restoreToVersion` methods to `svelte-ui/src/lib/stores/api.ts`
+- [ ] T015 Create `svelte-ui/src/lib/components/FieldDiff.svelte` component
+- [ ] T016 Create `svelte-ui/src/lib/components/HistoryPanel.svelte` component
+- [ ] T017 Add "History" button and `HistoryPanel` integration to `ApplicationEdit.svelte`
+
+**Checkpoint**: Frontend compiles, history UI renders
+
+---
+
+## Phase 3: Validation (Sequential)
+
+**Purpose**: Verify everything builds and existing tests pass
+
+- [ ] T018 Run `cd hono-api && npm run build` — TypeScript compiles
+- [ ] T019 Run `cd hono-api && npm run lint` — passes
+- [ ] T020 Run `cd svelte-ui && npm run build && npm run check` — Svelte compiles + type checks
+- [ ] T021 Run `cd svelte-ui && npm run lint` — passes
+- [ ] T022 Run existing shared E2E tests (`npm run test:e2e:svelte`) — 13 tests pass
+
+**Checkpoint**: No regressions introduced
+
+---
+
+## Phase 4: E2E Tests (Sequential)
+
+**Purpose**: Add and run history-specific E2E tests
+
+- [ ] T023 Add `test.describe.serial('History Panel - Svelte Snapshots', ...)` to `tests/e2e/history.spec.ts`
+- [ ] T024 Update `package.json` `test:e2e:svelte` grep pattern from `'History Panel'` to `'Vue Event Sourcing'`
+- [ ] T025 Run history E2E tests and fix any failures
+
+**Checkpoint**: All E2E tests pass, feature complete
+
+---
+
+## Summary
+
+**Total Tasks**: 25
+**Phases**:
+- Phase 1 (Foundation): 4 tasks — sequential
+- Phase 2A (Backend): 8 tasks — parallel with 2B
+- Phase 2B (Frontend): 5 tasks — parallel with 2A
+- Phase 3 (Validation): 5 tasks — sequential
+- Phase 4 (E2E Tests): 3 tasks — sequential
+
+**Parallel Opportunities**:
+- Phase 2A and 2B touch completely different directories (`hono-api/` vs `svelte-ui/`) — no conflicts

--- a/svelte-ui/src/lib/components/ApplicationEdit.svelte
+++ b/svelte-ui/src/lib/components/ApplicationEdit.svelte
@@ -26,6 +26,7 @@
   import InterviewStageForm from './InterviewStageForm.svelte';
   import InterviewStageItem from './InterviewStageItem.svelte';
   import ConfirmDialog from './ConfirmDialog.svelte';
+  import HistoryPanel from './HistoryPanel.svelte';
 
   interface Props {
     id?: string;
@@ -74,6 +75,7 @@
   let editingStage = $state<{ id: string; stage: InterviewStage } | null>(null);
   let showDeleteStageConfirm = $state(false);
   let stageToDelete = $state<string | null>(null);
+  let showHistory = $state(false);
 
   // Local stages for create mode
   let localStages = $state<InterviewStage[]>([]);
@@ -556,6 +558,17 @@
             </button>
           {/if}
 
+          <!-- History (edit mode only) -->
+          {#if isEditMode && application}
+            <button
+              type="button"
+              class="btn-secondary"
+              onclick={() => (showHistory = !showHistory)}
+            >
+              History
+            </button>
+          {/if}
+
           <!-- Delete (edit mode only) -->
           {#if isEditMode && application}
             <button
@@ -886,6 +899,20 @@
       confirmVariant="danger"
       onconfirm={handleConfirmDeleteStage}
       oncancel={() => { showDeleteStageConfirm = false; stageToDelete = null; }}
+    />
+  {/if}
+
+  <!-- History Panel -->
+  {#if showHistory && application}
+    <HistoryPanel
+      applicationId={application.id}
+      onclose={() => (showHistory = false)}
+      onrestored={async () => {
+        if (!application) return;
+        application = await api.getApplication(application.id);
+        populateFromApplication(application);
+        recaptureSnapshot();
+      }}
     />
   {/if}
 </div>

--- a/svelte-ui/src/lib/components/FieldDiff.svelte
+++ b/svelte-ui/src/lib/components/FieldDiff.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { FieldChange } from '$lib/types';
+
+  interface Props {
+    changes: FieldChange[];
+  }
+
+  let { changes }: Props = $props();
+
+  function formatValue(value: unknown): string {
+    if (value === null || value === undefined) return 'None';
+    if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+    return String(value);
+  }
+</script>
+
+{#if changes.length > 0}
+  <div class="space-y-2">
+    {#each changes as change}
+      <div class="text-sm">
+        <span class="font-medium text-gray-600 dark:text-gray-400">{change.label}:</span>
+        <div class="ml-2">
+          {#if change.oldValue !== null && change.oldValue !== undefined}
+            <span class="text-red-600 dark:text-red-400 line-through">{formatValue(change.oldValue)}</span>
+            <span class="mx-1 text-gray-400">&rarr;</span>
+          {/if}
+          <span class="text-green-600 dark:text-green-400">{formatValue(change.newValue)}</span>
+        </div>
+      </div>
+    {/each}
+  </div>
+{:else}
+  <p class="text-sm italic text-gray-500 dark:text-gray-400">No field changes recorded</p>
+{/if}

--- a/svelte-ui/src/lib/components/HistoryPanel.svelte
+++ b/svelte-ui/src/lib/components/HistoryPanel.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import type { HistoryEntry } from '$lib/types';
+  import { api } from '$lib/stores/api';
+  import FieldDiff from './FieldDiff.svelte';
+
+  interface Props {
+    applicationId: string;
+    onclose: () => void;
+    onrestored: () => void;
+  }
+
+  let { applicationId, onclose, onrestored }: Props = $props();
+
+  let entries = $state<HistoryEntry[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let expandedEntry = $state<string | null>(null);
+  let restoring = $state(false);
+
+  async function loadHistory() {
+    loading = true;
+    error = null;
+    try {
+      const result = await api.getHistory(applicationId);
+      entries = result.entries;
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to load history';
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    loadHistory();
+  });
+
+  function formatRelativeTime(isoString: string): string {
+    const now = Date.now();
+    const then = new Date(isoString).getTime();
+    const diffSeconds = Math.floor((now - then) / 1000);
+
+    if (diffSeconds < 60) return 'Just now';
+
+    const diffMinutes = Math.floor(diffSeconds / 60);
+    if (diffMinutes < 60) return `${diffMinutes}m ago`;
+
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays <= 7) return `${diffDays}d ago`;
+
+    return new Date(isoString).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+
+  function toggleExpand(entryId: string) {
+    expandedEntry = expandedEntry === entryId ? null : entryId;
+  }
+
+  async function handleRestore(entry: HistoryEntry) {
+    restoring = true;
+    try {
+      await api.restoreToVersion(applicationId, entry.sequence);
+      await loadHistory();
+      onrestored();
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to restore';
+    } finally {
+      restoring = false;
+    }
+  }
+</script>
+
+<div class="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
+  <!-- Header -->
+  <div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+    <h2 class="text-lg font-semibold text-gray-900 dark:text-white">History</h2>
+    <button onclick={onclose} aria-label="Close history panel" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+      <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Content (scrollable) -->
+  <div class="flex-1 overflow-y-auto p-4">
+    {#if loading}
+      <div class="flex justify-center py-12">
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+      </div>
+    {:else if error}
+      <div class="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-400 text-sm">
+        {error}
+      </div>
+    {:else if entries.length === 0}
+      <p class="text-gray-500 dark:text-gray-400 text-center py-6">No history entries yet.</p>
+    {:else}
+      <div class="space-y-1">
+        {#each entries as entry, i (entry.id)}
+          <div>
+            <button
+              onclick={() => toggleExpand(entry.id)}
+              class="w-full text-left p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 {expandedEntry === entry.id ? 'bg-gray-50 dark:bg-gray-700/50' : ''}"
+            >
+              <div class="flex items-start justify-between">
+                <div class="flex-1 min-w-0">
+                  <p class="text-sm font-medium text-gray-900 dark:text-white truncate">
+                    {entry.description}
+                  </p>
+                  <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    {formatRelativeTime(entry.createdAt)}
+                  </p>
+                </div>
+                {#if i === 0}
+                  <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-200">
+                    (current)
+                  </span>
+                {/if}
+              </div>
+            </button>
+
+            {#if expandedEntry === entry.id}
+              <div class="px-3 pb-3 space-y-3">
+                <FieldDiff changes={entry.changes} />
+                {#if i > 0}
+                  <button
+                    type="button"
+                    class="w-full text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium py-1.5 px-3 rounded-md border border-primary-200 dark:border-primary-800 hover:bg-primary-50 dark:hover:bg-primary-900/30"
+                    disabled={restoring}
+                    onclick={() => handleRestore(entry)}
+                  >
+                    {restoring ? 'Restoring...' : 'Restore to this point'}
+                  </button>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/svelte-ui/src/lib/stores/api.ts
+++ b/svelte-ui/src/lib/stores/api.ts
@@ -6,6 +6,7 @@ import type {
   UpdateInterviewStageInput,
   InterviewStage,
   PaginatedResponse,
+  PaginatedHistoryResponse,
   FilterState,
 } from '$lib/types';
 
@@ -113,5 +114,21 @@ export const api = {
       method: 'DELETE',
     });
     return handleResponse<void>(response);
+  },
+
+  // History
+  async getHistory(applicationId: string, page = 1, limit = 50): Promise<PaginatedHistoryResponse> {
+    const params = new URLSearchParams({ page: page.toString(), limit: limit.toString() });
+    const response = await fetch(`${API_BASE}/applications/${applicationId}/history?${params}`);
+    return handleResponse<PaginatedHistoryResponse>(response);
+  },
+
+  async restoreToVersion(applicationId: string, sequence: number): Promise<Application> {
+    const response = await fetch(`${API_BASE}/applications/${applicationId}/history/restore`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sequence }),
+    });
+    return handleResponse<Application>(response);
   },
 };

--- a/svelte-ui/src/lib/types/index.ts
+++ b/svelte-ui/src/lib/types/index.ts
@@ -152,6 +152,29 @@ export interface ErrorResponse {
   details?: Array<{ field: string; message: string }>;
 }
 
+// History types
+export interface FieldChange {
+  field: string;
+  label: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+export interface HistoryEntry {
+  id: string;
+  sequence: number;
+  description: string;
+  changes: FieldChange[];
+  createdAt: string;
+}
+
+export interface PaginatedHistoryResponse {
+  entries: HistoryEntry[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
 // Display helpers
 export const STATUS_LABELS: Record<ApplicationStatus, string> = {
   applied: 'Applied',

--- a/tests/e2e/history.spec.ts
+++ b/tests/e2e/history.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect, type Page } from '@playwright/test';
 
-// History/event sourcing is only implemented in the Vue+Nuxt stack (port 3020).
-// Non-Vue scripts in package.json use --grep-invert to exclude this describe block.
+// Shared history tests for Vue+Nuxt (event sourcing, port 3020) and Svelte+Hono (snapshots, port 3030).
+// Stacks without history support use --grep-invert 'History Panel' to exclude this file.
 
-test.describe.serial('History Panel - Vue Event Sourcing', () => {
+test.describe.serial('History Panel', () => {
   let applicationUrl: string;
   const uniqueCompany = `History Co ${Date.now()}`;
   const uniquePosition = `Engineer ${Date.now()}`;
@@ -35,7 +35,7 @@ test.describe.serial('History Panel - Vue Event Sourcing', () => {
   }
 
   async function closeHistory(page: Page) {
-    // Close button is the first button in the panel header (XMarkIcon)
+    // Close button is the first button in the panel header (XMarkIcon / SVG)
     await panel(page).locator('button').first().click();
     await expect(panel(page)).not.toBeVisible({ timeout: 5000 });
   }
@@ -45,7 +45,6 @@ test.describe.serial('History Panel - Vue Event Sourcing', () => {
 
     await openHistory(page);
 
-    // The creation event: Created application "Company - Position"
     await expect(panel(page).locator('text=Created application')).toBeVisible({ timeout: 5000 });
     await expect(panel(page).locator('text=(current)')).toBeVisible();
 
@@ -61,8 +60,7 @@ test.describe.serial('History Panel - Vue Event Sourcing', () => {
 
     await openHistory(page);
 
-    // buildInput() sends all form fields, so description is "Updated N fields"
-    // The newest entry (first in list) should contain "Updated" and be marked (current)
+    // The newest entry should contain "Updated" and be marked (current)
     const newestEntry = entries(page).first();
     await expect(newestEntry).toContainText(/Updated/, { timeout: 5000 });
     await expect(newestEntry).toContainText('(current)');
@@ -87,7 +85,7 @@ test.describe.serial('History Panel - Vue Event Sourcing', () => {
     const newestEntry = entries(page).first();
     await newestEntry.locator('button').first().click();
 
-    // The EventDiff should show the "Company Name" field label
+    // Both Vue EventDiff and Svelte FieldDiff render "Company Name:" with a colon
     await expect(panel(page).locator('text=Company Name:')).toBeVisible({ timeout: 3000 });
     // Old value shown with strikethrough
     await expect(panel(page).locator('.line-through')).toBeVisible();
@@ -126,14 +124,13 @@ test.describe.serial('History Panel - Vue Event Sourcing', () => {
     await expect(page.locator('input[placeholder="Company Name *"]')).toHaveValue(`${uniqueCompany} Updated`);
   });
 
-  test('should show "(current)" on the restore event after restore', async ({ page }) => {
+  test('should show "Restored to version" after restore', async ({ page }) => {
     await page.goto(applicationUrl);
     await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('input[placeholder="Company Name *"]', { timeout: 10000 });
 
     await openHistory(page);
 
-    // After restore, a "Restored to version N" event is the newest
     const newestEntry = entries(page).first();
     await expect(newestEntry).toContainText('Restored to version', { timeout: 5000 });
     await expect(newestEntry).toContainText('(current)');


### PR DESCRIPTION
## Summary
- Add snapshot-based history tracking to the Hono+Drizzle backend and SvelteKit frontend — each mutation captures the full application state as JSONB, with field-level diffs computed at read time
- New `HistoryPanel` and `FieldDiff` components provide a sliding timeline panel with expandable diffs and "Restore to this point" functionality
- Unified the `History Panel` E2E test block so both Vue (event sourcing) and Svelte (snapshots) share a single parameterized test suite

### Backend
- `applicationHistory` table in `svelte_hono` schema (Drizzle migration included)
- `history.service.ts`: `captureSnapshot`, `recordHistory`, `listHistory`, `restoreToVersion`, `computeFieldDiffs`
- Wired into `application.service.ts` and `interview-stage.service.ts` (post-mutation snapshots, pre-delete snapshots)
- `GET /:id/history` and `POST /:id/history/restore` API routes
- Extracted shared utils (`toApplicationResponse`, `formatDate`, `formatDateTime`) to `shared.ts`

### Frontend
- `HistoryPanel.svelte`: fixed right-side sliding panel (w-96) with timeline, expandable entries, restore button
- `FieldDiff.svelte`: old/new value display with red strikethrough → green styling
- "History" button in `ApplicationEdit.svelte` (edit mode only), with `onrestored` callback to refresh form

### Tests & Infrastructure
- Unified `History Panel` E2E tests shared by Vue and Svelte (aligned `FieldDiff`/`EventDiff` colon selector contract)
- Updated `package.json` grep patterns: stacks without history exclude `'History Panel'`

## Test Plan
- [x] `cd hono-api && npm run build && npm run lint` — passes
- [x] `cd svelte-ui && npm run build && npm run check && npm run lint` — passes
- [x] `npm run test:e2e:svelte` — 25 tests pass (13 CRUD + 4 dark mode + 2 simple + 6 history)
- [x] `npm run test:e2e:vue` — 25 tests pass (same breakdown, shared history block)

---
🤖 Generated with [Claude Code](https://claude.ai/code)