### PR TITLE
chore: update Claude Code settings and enable agent teams

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,11 +25,13 @@
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
-    "ralph-loop@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "sandbox": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Remove unused `ralph-loop` plugin from enabled plugins
- Enable experimental agent teams via `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var

## Test Plan
- [x] Verify Claude Code loads settings correctly with updated config

---
Generated with [Claude Code](https://claude.ai/code)