### PR TITLE
chore(skills): updates /js-deps, /learn and /ship-it skills from source repo which adds help options and symlinks

### DIFF
--- a/.agent/skills/js-deps
+++ b/.agent/skills/js-deps
@@ -1,0 +1,1 @@
+../../.agents/skills/js-deps

--- a/.agent/skills/learn
+++ b/.agent/skills/learn
@@ -1,0 +1,1 @@
+../../.agents/skills/learn

--- a/.agent/skills/ship-it
+++ b/.agent/skills/ship-it
@@ -1,0 +1,1 @@
+../../.agents/skills/ship-it

--- a/.agents/skills/js-deps/SKILL.md
+++ b/.agents/skills/js-deps/SKILL.md
@@ -3,13 +3,13 @@ name: js-deps
 description: >
   Maintain JavaScript/Node.js packages through security audits or dependency updates on a dedicated branch.
   Supports npm, yarn, pnpm, and bun. Use for: security audits, CVE fixes, vulnerability checks,
-  dependency updates, package upgrades, or when user types "/js-deps" with or without specific package names or glob patterns.
+  dependency updates, package upgrades, or when user types "/js-deps" with or without specific package names or glob patterns. Use "help" or "--help" to show update options.
 license: MIT
 compatibility: Requires git, a JavaScript package manager (npm, yarn, pnpm, or bun), and network access to package registries
 metadata:
   author: Gregory Murray
   repository: github.com/whatifwedigdeeper/agent-skills
-  version: "0.3"
+  version: "0.4"
 ---
 
 # JS Deps
@@ -17,6 +17,8 @@ metadata:
 ## Arguments
 
 Specific package names (e.g. `jest @types/jest`), `.` for all packages, or glob patterns (e.g. `@testing-library/*`).
+
+If `$ARGUMENTS` is `help`, `--help`, `-h`, or `?`, skip the workflow and read [references/options.md](references/options.md).
 
 ## Workflow Selection
 

--- a/.agents/skills/js-deps/references/options.md
+++ b/.agents/skills/js-deps/references/options.md
@@ -1,0 +1,48 @@
+# Help Options
+
+Read the skill's SKILL.md file and display its content as formatted documentation (title, arguments, workflows, process steps, and notes). Then present the questions below using `AskUserQuestion`. The second question depends on the answer to the first.
+
+## Question 1: Workflow type
+
+Use `multiSelect: false`.
+
+| Option | Description |
+|--------|-------------|
+| Update dependencies | Update packages to newer versions |
+| Security fixes only | Only fix packages with known vulnerabilities |
+
+## Question 2a: Update filters (if "Update dependencies" was selected)
+
+Use `multiSelect: true`. Only selected version types are included in the update.
+
+| Option | Description |
+|--------|-------------|
+| Major | Include major version upgrades (e.g. 2.x → 3.x) |
+| Minor | Include minor version updates (e.g. 2.1 → 2.2) |
+| Patch | Include patch-level updates (e.g. 2.1.3 → 2.1.4) |
+| Skip .0 patches (Recommended) | Skip x.y.0 releases and wait for x.y.1+ bugfix releases |
+
+## Question 2b: Severity filter (if "Security fixes only" was selected)
+
+Use `multiSelect: true`. Nothing selected by default means all severities are included.
+
+| Option | Description |
+|--------|-------------|
+| Critical | Only fix critical severity vulnerabilities |
+| High | Include high severity vulnerabilities |
+| Moderate | Include moderate severity vulnerabilities |
+| All vulnerabilities (Recommended) | Fix all reported vulnerabilities regardless of severity |
+
+## How to Apply
+
+**Update dependencies path:**
+- **Major selected**: Include packages where the new major version differs from the current major version.
+- **Minor selected**: Include packages where the new minor version differs (but major is the same).
+- **Patch selected**: Include packages where only the patch version differs.
+- **None selected**: If no version types are selected, default to including all (major, minor, and patch).
+- **Skip .0 patches**: If the latest version ends in `.0` (e.g. `2.1.0`), skip it and keep the current version.
+
+**Security fixes path:**
+- Run `$PM audit` to identify vulnerable packages.
+- Filter audit results by the selected severity levels before applying fixes.
+- Use `$PM audit fix` (npm) or manually update vulnerable packages to patched versions.

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -11,12 +11,18 @@ compatibility: Requires bash shell and file system write access
 metadata:
   author: Gregory Murray
   repository: github.com/whatifwedigdeeper/agent-skills
-  version: "0.4"
+  version: "0.5"
 ---
 
 # Learn from Conversation
 
 Analyze the conversation to extract lessons learned, then persist them to AI assistant configuration files.
+
+## Arguments
+
+Optional text to narrow what to learn (e.g. `sandbox workaround`, `that build fix`).
+
+If `$ARGUMENTS` is `help`, `--help`, `-h`, or `?`, skip the workflow and read [references/options.md](references/options.md).
 
 ## Supported Assistants
 

--- a/.agents/skills/learn/references/options.md
+++ b/.agents/skills/learn/references/options.md
@@ -1,0 +1,30 @@
+# Help Options
+
+Read the skill's SKILL.md file and display its content as formatted documentation (title, supported assistants, routing logic, and process steps). Then present two questions using `AskUserQuestion`. After the user selects options, store their choices and apply them during the workflow.
+
+## Question 1: Destination
+
+Use `multiSelect: false`. These options are mutually exclusive.
+
+| Option | Description |
+|--------|-------------|
+| Auto-route (default) | Use the routing decision tree to choose skills or config files |
+| Skills only | Only create or update skills, don't modify config files |
+| Config only | Only update config files, don't create new skills |
+
+## Question 2: Additional options
+
+Use `multiSelect: true`. These can be combined.
+
+| Option | Description |
+|--------|-------------|
+| Dry run | Show what would be learned without writing any files |
+| All assistants | Write to every detected config file without prompting |
+
+## How to Apply
+
+When options are selected, apply them by adjusting the workflow:
+- **Skills only**: In the routing step (Step 3), always route to skill creation/update (Routes B and C). Skip Route A (config file updates).
+- **Config only**: In the routing step (Step 3), always route to config file updates (Route A). Skip Routes B and C (skill creation/update).
+- **Dry run**: Run the full analysis and categorization, display the proposed changes, then stop without writing any files.
+- **All assistants**: Skip the "prompt user to select which to update" step when multiple configs are found. Write to all detected config files.

--- a/.agents/skills/ship-it/SKILL.md
+++ b/.agents/skills/ship-it/SKILL.md
@@ -9,7 +9,7 @@ compatibility: Requires git and GitHub CLI (gh) with authentication
 metadata:
   author: Gregory Murray
   repository: github.com/whatifwedigdeeper/agent-skills
-  version: "0.2"
+  version: "0.3"
 ---
 
 # Ship: Branch, Commit, Push & PR
@@ -17,6 +17,8 @@ metadata:
 ## Arguments
 
 Optional text to derive branch name, commit message, or PR title (e.g. `fix login timeout`).
+
+If `$ARGUMENTS` is `help`, `--help`, `-h`, or `?`, skip the workflow and read [references/options.md](references/options.md).
 
 ## Process
 

--- a/.agents/skills/ship-it/references/options.md
+++ b/.agents/skills/ship-it/references/options.md
@@ -1,0 +1,31 @@
+# Help Options
+
+Read the skill's SKILL.md file and display its content as formatted documentation (title, arguments, process steps, and notes). Then present two questions using `AskUserQuestion`. After the user selects options, store their choices and apply them during the workflow.
+
+## Question 1: Workflow scope
+
+Use `multiSelect: false`. These options are mutually exclusive.
+
+| Option | Description |
+|--------|-------------|
+| Full PR (default) | Branch, commit, push, and open a pull request |
+| Commit only | Stage and commit but don't push or create a PR |
+| Push only | Commit and push but don't create a PR |
+
+## Question 2: PR options
+
+Use `multiSelect: true`. These can be combined. Skip this question if the user selected "Commit only" or "Push only" above.
+
+| Option | Description |
+|--------|-------------|
+| Standard PR (Recommended) | No extra options, just create the PR |
+| Draft PR | Create the pull request as a draft |
+| Self-merge | Create the PR and immediately merge it |
+
+## How to Apply
+
+When options are selected, apply them by adjusting the workflow:
+- **Commit only**: Stop after Step 3 (Stage & Commit). Skip push and PR creation.
+- **Push only**: Stop after Step 4 (Push). Skip PR creation.
+- **Draft PR**: Add `--draft` flag to `gh pr create`.
+- **Self-merge**: After creating the PR, run `gh pr merge --merge` and delete the branch.


### PR DESCRIPTION
## Summary
- Add `references/options.md` with interactive help menus (`AskUserQuestion`) for js-deps, learn, and ship-it skills
- Bump skill versions: js-deps 0.4, learn 0.5, ship-it 0.3
- Add `.agent/skills/` symlinks pointing to `.agents/skills/` for backward compatibility

## Test Plan
- [x] Run `/js-deps help` — verify interactive options are presented
- [x] Run `/learn help` — verify interactive options are presented
- [x] Run `/ship-it help` — verify interactive options are presented
- [x] Verify symlinks resolve correctly: `ls -la .agent/skills/`

---
Generated with [Claude Code](https://claude.ai/code)