### PR TITLE
chore: add stop:all script and remove redundant kill:all-next-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "docs:types:koa-api": "npx -y ts-to-mermaid koa-api/src/types/index.ts --save docs/types/koa-api/ && echo >> docs/types/koa-api/index.mermaid",
     "docs:types:svelte-ui": "npx -y ts-to-mermaid svelte-ui/src/lib/types/index.ts --save docs/types/svelte-ui/ && echo >> docs/types/svelte-ui/index.mermaid",
     "docs:types": "npm run docs:types:nuxt && npm run docs:types:ui && npm run docs:types:react-ui && npm run docs:types:koa-api && npm run docs:types:svelte-ui",
+    "stop": "bash scripts/stop-all.sh",
     "kill:all-next-dev": "pkill -f \"next dev\"",
     "cleanup:test-data": "node scripts/cleanup-test-data.mjs --"
   },

--- a/package.json
+++ b/package.json
@@ -113,8 +113,7 @@
     "docs:types:koa-api": "npx -y ts-to-mermaid koa-api/src/types/index.ts --save docs/types/koa-api/ && echo >> docs/types/koa-api/index.mermaid",
     "docs:types:svelte-ui": "npx -y ts-to-mermaid svelte-ui/src/lib/types/index.ts --save docs/types/svelte-ui/ && echo >> docs/types/svelte-ui/index.mermaid",
     "docs:types": "npm run docs:types:nuxt && npm run docs:types:ui && npm run docs:types:react-ui && npm run docs:types:koa-api && npm run docs:types:svelte-ui",
-    "stop": "bash scripts/stop-all.sh",
-    "kill:all-next-dev": "pkill -f \"next dev\"",
+    "stop:all": "bash scripts/stop-all.sh",
     "cleanup:test-data": "node scripts/cleanup-test-data.mjs --"
   },
   "keywords": [],

--- a/scripts/stop-all.sh
+++ b/scripts/stop-all.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Stop all dev servers by killing processes on known ports
+
+PORTS=(
+  3000  # Next.js UI
+  3001  # Express API
+  3010  # React-Koa UI
+  3020  # Vue UI
+  3030  # Svelte UI
+  3050  # TanStack UI
+  5001  # Hono API
+  5010  # Koa API
+  5030  # (reserved)
+  5040  # Nuxt API
+  5050  # Nest API
+)
+
+stopped=0
+for port in "${PORTS[@]}"; do
+  pids=$(lsof -ti :"$port" 2>/dev/null)
+  if [ -n "$pids" ]; then
+    echo "Stopping port $port (PIDs: $(echo $pids | tr '\n' ' '))"
+    echo "$pids" | xargs kill 2>/dev/null
+    stopped=$((stopped + 1))
+  fi
+done
+
+if [ "$stopped" -eq 0 ]; then
+  echo "No dev servers running."
+else
+  echo "Stopped processes on $stopped port(s)."
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/stop-all.sh` that iterates over all 11 known dev ports and sends SIGTERM to any running processes
- Wired up as `npm run stop:all` in root `package.json`
- Removed redundant `kill:all-next-dev` script (port 3000 is already covered by stop:all)
- Ports covered: UI (3000, 3010, 3020, 3030, 3050) and API (3001, 5001, 5010, 5030, 5040, 5050)

## Test Plan
- [x] Run `npm run stop:all` with dev servers running — verify they are terminated
- [x] Run `npm run stop:all` with no servers running — verify "No dev servers running." message

---
Generated with [Claude Code](https://claude.ai/code) by Claude Opus 4.6