### PR TITLE
feat: make textareas vertically resizable across all 5 UI stacks

### DIFF
--- a/react-ui/src/components/applications/ApplicationEdit.tsx
+++ b/react-ui/src/components/applications/ApplicationEdit.tsx
@@ -928,7 +928,7 @@ export function ApplicationEdit() {
                 updateField("specialRequirements", e.target.value)
               }
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-xs transition-colors resize-none focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-xs transition-colors resize-y focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
               placeholder="Portfolio required, specific skills..."
             />
           </div>
@@ -946,7 +946,7 @@ export function ApplicationEdit() {
               value={form.notes}
               onChange={(e) => updateField("notes", e.target.value)}
               rows={4}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-xs transition-colors resize-none focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-xs transition-colors resize-y focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
               placeholder="Referral info, interview prep notes..."
             />
           </div>

--- a/react-ui/src/components/ui/Input.tsx
+++ b/react-ui/src/components/ui/Input.tsx
@@ -70,7 +70,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           ref={ref}
           id={inputId}
           className={cn(
-            "w-full px-3 py-2 border rounded-lg shadow-xs transition-colors resize-none",
+            "w-full px-3 py-2 border rounded-lg shadow-xs transition-colors resize-y",
             "focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:border-primary-500",
             "dark:bg-gray-800 dark:border-gray-600 dark:text-white",
             error

--- a/specs/013-resizable-textareas/spec.md
+++ b/specs/013-resizable-textareas/spec.md
@@ -1,0 +1,26 @@
+# Feature Specification: Resizable Textareas
+
+**Created**: 2026-02-18
+**Status**: Draft
+**Input**: User requirement: "Special Requirements and Notes textareas should be expandable with the usual draggable right corner."
+
+## User Scenarios
+
+### User Story 1 - Resize textarea vertically (Priority: P1)
+
+As a user editing an application, I want to drag the bottom-right corner of the Special Requirements and Notes textareas to make them taller, so I can see more of my content while editing.
+
+**Acceptance Scenarios**:
+
+1. **Given** I navigate to the application edit/create form, **When** I hover over the bottom-right corner of a textarea, **Then** I see a resize cursor.
+2. **Given** I drag the resize handle downward, **When** I release, **Then** the textarea is taller and shows more content.
+3. **Given** I try to resize horizontally, **When** I drag sideways, **Then** the width does not change (vertical only).
+
+## Requirements
+
+- All 5 UI implementations must use `resize: vertical` (Tailwind `resize-y`) on Special Requirements and Notes textareas
+- No horizontal resize (textareas are full-width)
+
+## Success Criteria
+
+- E2E test confirms `getComputedStyle(textarea).resize === 'vertical'` for `#specialRequirements` and `#notes` across all 5 stacks

--- a/specs/013-resizable-textareas/spec.md
+++ b/specs/013-resizable-textareas/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Resizable Textareas
 
 **Created**: 2026-02-18
-**Status**: Draft
+**Status**: Complete
 **Input**: User requirement: "Special Requirements and Notes textareas should be expandable with the usual draggable right corner."
 
 ## User Scenarios

--- a/svelte-ui/src/lib/components/ApplicationEdit.svelte
+++ b/svelte-ui/src/lib/components/ApplicationEdit.svelte
@@ -794,7 +794,7 @@
             <textarea
               id="specialRequirements"
               rows="3"
-              class="input mt-1"
+              class="input mt-1 resize-y"
               placeholder="Portfolio required, specific skills..."
               bind:value={specialRequirements}
             ></textarea>
@@ -806,7 +806,7 @@
             <textarea
               id="notes"
               rows="4"
-              class="input mt-1"
+              class="input mt-1 resize-y"
               placeholder="Referral info, interview prep notes..."
               bind:value={notes}
             ></textarea>

--- a/tanstack-ui/src/components/applications/ApplicationEdit.tsx
+++ b/tanstack-ui/src/components/applications/ApplicationEdit.tsx
@@ -912,7 +912,7 @@ export function ApplicationEdit({ applicationId }: ApplicationEditProps) {
                 updateField("specialRequirements", e.target.value)
               }
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-xs transition-colors resize-none focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-xs transition-colors resize-y focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
               placeholder="Portfolio required, specific skills..."
             />
           </div>
@@ -930,7 +930,7 @@ export function ApplicationEdit({ applicationId }: ApplicationEditProps) {
               value={form.notes}
               onChange={(e) => updateField("notes", e.target.value)}
               rows={4}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-xs transition-colors resize-none focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-xs transition-colors resize-y focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
               placeholder="Referral info, interview prep notes..."
             />
           </div>

--- a/tanstack-ui/src/components/ui/Input.tsx
+++ b/tanstack-ui/src/components/ui/Input.tsx
@@ -70,7 +70,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           ref={ref}
           id={inputId}
           className={cn(
-            "w-full px-3 py-2 border rounded-lg shadow-xs transition-colors resize-none",
+            "w-full px-3 py-2 border rounded-lg shadow-xs transition-colors resize-y",
             "focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:border-primary-500",
             "dark:bg-gray-800 dark:border-gray-600 dark:text-white",
             error

--- a/tests/e2e/application-crud.spec.ts
+++ b/tests/e2e/application-crud.spec.ts
@@ -245,6 +245,18 @@ test.describe('Application CRUD - Inline Edit', () => {
     await expect(page.locator('#salaryMax')).toHaveValue('150000');
   });
 
+  test('textareas should be vertically resizable', async ({ page }) => {
+    await page.goto('/applications/new');
+    await page.waitForLoadState('domcontentloaded');
+
+    for (const id of ['#specialRequirements', '#notes']) {
+      const resize = await page.locator(id).evaluate(
+        (el) => getComputedStyle(el).resize
+      );
+      expect(resize).toBe('vertical');
+    }
+  });
+
   test('should show error when salary min exceeds max', async ({ page }) => {
     await page.goto('/applications/new');
     await page.waitForLoadState('domcontentloaded');

--- a/ui/src/components/applications/ApplicationEdit.tsx
+++ b/ui/src/components/applications/ApplicationEdit.tsx
@@ -945,7 +945,7 @@ export function ApplicationEdit({ applicationId }: ApplicationEditProps): React.
               value={form.specialRequirements}
               onChange={handleChange}
               className={cn(
-                'block w-full rounded-md shadow-sm',
+                'block w-full rounded-md shadow-sm resize-y',
                 'border-gray-300 focus:border-blue-500 focus:ring-blue-500',
                 'dark:border-slate-600 dark:focus:border-blue-400 dark:focus:ring-blue-400',
                 'placeholder:text-gray-400 dark:placeholder:text-slate-500',
@@ -968,7 +968,7 @@ export function ApplicationEdit({ applicationId }: ApplicationEditProps): React.
               value={form.notes}
               onChange={handleChange}
               className={cn(
-                'block w-full rounded-md shadow-sm',
+                'block w-full rounded-md shadow-sm resize-y',
                 'border-gray-300 focus:border-blue-500 focus:ring-blue-500',
                 'dark:border-slate-600 dark:focus:border-blue-400 dark:focus:ring-blue-400',
                 'placeholder:text-gray-400 dark:placeholder:text-slate-500',

--- a/vue-ui/src/views/ApplicationEdit.vue
+++ b/vue-ui/src/views/ApplicationEdit.vue
@@ -903,7 +903,7 @@ onUnmounted(() => {
               id="specialRequirements"
               v-model="specialRequirements"
               rows="3"
-              class="input mt-1"
+              class="input mt-1 resize-y"
               placeholder="Portfolio required, specific skills..."
             />
           </div>
@@ -918,7 +918,7 @@ onUnmounted(() => {
               id="notes"
               v-model="notes"
               rows="4"
-              class="input mt-1"
+              class="input mt-1 resize-y"
               placeholder="Referral info, interview prep notes..."
             />
           </div>


### PR DESCRIPTION
## Summary
- Add `resize-y` (vertical resize) to Special Requirements and Notes textareas across all 5 UI implementations (tanstack-ui, react-ui, Next.js ui, vue-ui, svelte-ui)
- Changed `resize-none` to `resize-y` in tanstack-ui and react-ui; added `resize-y` class to the other 3 stacks for consistent behavior
- Added E2E test verifying `getComputedStyle(textarea).resize === 'vertical'` for `#specialRequirements` and `#notes`, shared across all stacks

## Test Plan
- [x] `npm run build` — all packages compile
- [x] `npm run lint` — no lint errors
- [x] `npm test` — unit/integration tests pass
- [x] E2E tests pass on all 5 stacks (Next.js, React-Koa, Vue-Nuxt, Svelte-Hono, TanStack-NestJS)

---
Generated with [Claude Code](https://claude.ai/code)