### PR TITLE
fix: responsive layout and button height consistency in tanstack-ui

### DIFF
--- a/tanstack-ui/src/components/applications/ApplicationCard.tsx
+++ b/tanstack-ui/src/components/applications/ApplicationCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Link } from "@tanstack/react-router";
 import type { Application } from "../../types/application";
 import { Card, Badge, RatingDisplay, ConfirmDialog } from "../ui";
@@ -19,6 +19,18 @@ export function ApplicationCard({
 }: ApplicationCardProps) {
   const [showMenu, setShowMenu] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const [menuPosition, setMenuPosition] = useState({ top: 0, right: 0 });
+
+  useEffect(() => {
+    if (showMenu && menuButtonRef.current) {
+      const rect = menuButtonRef.current.getBoundingClientRect();
+      setMenuPosition({
+        top: rect.bottom + 4,
+        right: window.innerWidth - rect.right,
+      });
+    }
+  }, [showMenu]);
 
   const categoryLabel = application.companyCategory
     ? COMPANY_CATEGORIES.find((c) => c.value === application.companyCategory)
@@ -38,11 +50,11 @@ export function ApplicationCard({
       <Card
         hoverable
         className={cn(
-          "relative",
+          "relative overflow-hidden",
           application.isArchived && "opacity-60"
         )}
       >
-        <div className="flex items-start p-4">
+        <div className="flex items-start p-4 min-w-0">
           <Link to="/applications/$id" params={{ id: application.id }} className="flex-1 min-w-0 block">
             <div className="flex items-center gap-2 mb-1">
               <h3 className="text-lg font-semibold text-gray-900 dark:text-white truncate">
@@ -102,6 +114,7 @@ export function ApplicationCard({
             onClick={(e) => e.stopPropagation()}
           >
             <button
+              ref={menuButtonRef}
               onClick={() => setShowMenu(!showMenu)}
               className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
               aria-label="Actions"
@@ -110,50 +123,53 @@ export function ApplicationCard({
                 <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
               </svg>
             </button>
-
-            {showMenu && (
-              <>
-                <div
-                  className="fixed inset-0 z-10"
-                  onClick={() => setShowMenu(false)}
-                />
-                <div className="absolute right-0 mt-1 z-20 w-48 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1">
-                  <button
-                    onClick={() => {
-                      setShowMenu(false);
-                      onArchive();
-                    }}
-                    className="flex items-center w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
-                  >
-                    {application.isArchived ? (
-                      <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5m6 4.125 2.25 2.25m0 0 2.25 2.25M12 13.875l2.25-2.25M12 13.875l-2.25 2.25M3.75 7.5h16.5" />
-                      </svg>
-                    ) : (
-                      <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.75 7.5h16.5" />
-                      </svg>
-                    )}
-                    {application.isArchived ? "Restore" : "Archive"}
-                  </button>
-                  <button
-                    onClick={() => {
-                      setShowMenu(false);
-                      setShowDeleteConfirm(true);
-                    }}
-                    className="flex items-center w-full px-4 py-2 text-left text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700"
-                  >
-                    <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                    </svg>
-                    Delete
-                  </button>
-                </div>
-              </>
-            )}
           </div>
         </div>
       </Card>
+
+      {showMenu && (
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setShowMenu(false)}
+          />
+          <div
+            className="fixed z-20 w-48 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1"
+            style={{ top: menuPosition.top, right: menuPosition.right }}
+          >
+            <button
+              onClick={() => {
+                setShowMenu(false);
+                onArchive();
+              }}
+              className="flex items-center w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              {application.isArchived ? (
+                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5m6 4.125 2.25 2.25m0 0 2.25 2.25M12 13.875l2.25-2.25M12 13.875l-2.25 2.25M3.75 7.5h16.5" />
+                </svg>
+              ) : (
+                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.75 7.5h16.5" />
+                </svg>
+              )}
+              {application.isArchived ? "Restore" : "Archive"}
+            </button>
+            <button
+              onClick={() => {
+                setShowMenu(false);
+                setShowDeleteConfirm(true);
+              }}
+              className="flex items-center w-full px-4 py-2 text-left text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+              </svg>
+              Delete
+            </button>
+          </div>
+        </>
+      )}
 
       <ConfirmDialog
         isOpen={showDeleteConfirm}

--- a/tanstack-ui/src/components/applications/ApplicationList.tsx
+++ b/tanstack-ui/src/components/applications/ApplicationList.tsx
@@ -101,7 +101,7 @@ export function ApplicationList({
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-4">
+      <div className="grid gap-4 min-w-0">
         {applications.map((application) => (
           <ApplicationCard
             key={application.id}

--- a/tanstack-ui/src/components/applications/FilterBar.tsx
+++ b/tanstack-ui/src/components/applications/FilterBar.tsx
@@ -150,20 +150,20 @@ export function FilterBar({
         </div>
 
         <div className="flex items-center gap-2">
-          <Button variant="secondary" size="sm" onClick={onImportClick}>
+          <Button variant="secondary" size="sm" onClick={onImportClick} className="h-[38px] whitespace-nowrap px-5">
             Import CSV
           </Button>
           <a
             href={getExportUrl()}
             download
-            className="inline-flex items-center justify-center font-medium rounded-lg transition-colors focus:outline-hidden focus:ring-2 focus:ring-offset-2 bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-500 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 px-3 py-1.5 text-sm"
+            className="inline-flex items-center justify-center font-medium rounded-lg transition-colors focus:outline-hidden focus:ring-2 focus:ring-offset-2 bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-500 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 h-[38px] whitespace-nowrap px-5 text-sm"
           >
             Export CSV
           </a>
           <a
             href={getSampleCsvUrl()}
             download
-            className="inline-flex items-center justify-center font-medium rounded-lg transition-colors focus:outline-hidden focus:ring-2 focus:ring-offset-2 bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-500 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 px-3 py-1.5 text-sm"
+            className="inline-flex items-center justify-center font-medium rounded-lg transition-colors focus:outline-hidden focus:ring-2 focus:ring-offset-2 bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-500 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 h-[38px] whitespace-nowrap px-4 text-sm"
           >
             Template
           </a>
@@ -174,7 +174,7 @@ export function FilterBar({
               onSortByChange(e.target.value as SortState["sortBy"])
             }
             options={SORT_OPTIONS}
-            className="w-36"
+            className="w-36 h-[38px]"
           />
           <Button
             variant="ghost"

--- a/tanstack-ui/src/components/applications/FilterBar.tsx
+++ b/tanstack-ui/src/components/applications/FilterBar.tsx
@@ -67,7 +67,7 @@ export function FilterBar({
       {/* Filter Controls */}
       <div className="flex flex-wrap items-end gap-4">
         {/* Status Filter */}
-        <div className="w-40">
+        <div className="w-full min-[480px]:w-40">
           <Select
             label="Status"
             value={filters.status[0] || ""}
@@ -81,7 +81,7 @@ export function FilterBar({
         </div>
 
         {/* Category Filter */}
-        <div className="w-44">
+        <div className="w-full min-[480px]:w-44">
           <Select
             label="Category"
             value={filters.companyCategory || ""}
@@ -96,7 +96,7 @@ export function FilterBar({
         </div>
 
         {/* Source Filter */}
-        <div className="w-40">
+        <div className="w-full min-[480px]:w-40">
           <Select
             label="Source"
             value={filters.jobSource || ""}
@@ -109,7 +109,7 @@ export function FilterBar({
         </div>
 
         {/* Skills Match Filter */}
-        <div className="w-32">
+        <div className="w-full min-[480px]:w-32">
           <Select
             label="Skills"
             value={filters.skillsMatchMin?.toString() || ""}
@@ -142,80 +142,84 @@ export function FilterBar({
       </div>
 
       {/* Sort Controls and Results Count */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="text-sm text-gray-500 dark:text-gray-400">
           {resultCount === totalCount
             ? `${totalCount} application${totalCount !== 1 ? "s" : ""}`
             : `${resultCount} of ${totalCount} applications`}
         </div>
 
-        <div className="flex items-center gap-2">
-          <Button variant="secondary" size="sm" onClick={onImportClick} className="h-[38px] whitespace-nowrap px-5">
-            Import CSV
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant="secondary" size="sm" onClick={onImportClick} className="h-[38px] whitespace-nowrap px-3 sm:px-5">
+            <span className="sm:hidden">Import</span>
+            <span className="hidden sm:inline">Import CSV</span>
           </Button>
           <a
             href={getExportUrl()}
             download
-            className="inline-flex items-center justify-center font-medium rounded-lg transition-colors focus:outline-hidden focus:ring-2 focus:ring-offset-2 bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-500 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 h-[38px] whitespace-nowrap px-5 text-sm"
+            className="inline-flex items-center justify-center font-medium rounded-lg transition-colors focus:outline-hidden focus:ring-2 focus:ring-offset-2 bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-500 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 h-[38px] whitespace-nowrap px-3 sm:px-5 text-sm"
           >
-            Export CSV
+            <span className="sm:hidden">Export</span>
+            <span className="hidden sm:inline">Export CSV</span>
           </a>
           <a
             href={getSampleCsvUrl()}
             download
-            className="inline-flex items-center justify-center font-medium rounded-lg transition-colors focus:outline-hidden focus:ring-2 focus:ring-offset-2 bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-500 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 h-[38px] whitespace-nowrap px-4 text-sm"
+            className="inline-flex items-center justify-center font-medium rounded-lg transition-colors focus:outline-hidden focus:ring-2 focus:ring-offset-2 bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-500 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 h-[38px] whitespace-nowrap px-3 sm:px-4 text-sm"
           >
             Template
           </a>
-          <div className="w-px h-6 bg-gray-300 dark:bg-gray-600 mx-1" />
-          <Select
-            value={sorting.sortBy}
-            onChange={(e) =>
-              onSortByChange(e.target.value as SortState["sortBy"])
-            }
-            options={SORT_OPTIONS}
-            className="w-36 h-[38px]"
-          />
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onSortDirToggle}
-            aria-label={
-              sorting.sortDir === "asc"
-                ? "Sort ascending"
-                : "Sort descending"
-            }
-          >
-            {sorting.sortDir === "asc" ? (
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12"
-                />
-              </svg>
-            ) : (
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M3 4h13M3 8h9m-9 4h9m5-4v12m0 0l-4-4m4 4l4-4"
-                />
-              </svg>
-            )}
-          </Button>
+          <div className="hidden sm:block w-px h-6 bg-gray-300 dark:bg-gray-600 mx-1" />
+          <div className="flex items-center gap-2">
+            <Select
+              value={sorting.sortBy}
+              onChange={(e) =>
+                onSortByChange(e.target.value as SortState["sortBy"])
+              }
+              options={SORT_OPTIONS}
+              className="w-36 h-[38px]"
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onSortDirToggle}
+              aria-label={
+                sorting.sortDir === "asc"
+                  ? "Sort ascending"
+                  : "Sort descending"
+              }
+            >
+              {sorting.sortDir === "asc" ? (
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 4h13M3 8h9m-9 4h9m5-4v12m0 0l-4-4m4 4l4-4"
+                  />
+                </svg>
+              )}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/tanstack-ui/src/components/common/Header.tsx
+++ b/tanstack-ui/src/components/common/Header.tsx
@@ -30,9 +30,9 @@ export function Header() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo / Title */}
-          <Link to="/" className="flex items-center gap-3">
+          <Link to="/" className="flex items-center gap-3 min-w-0">
             <svg
-              className="w-8 h-8 text-primary-600"
+              className="w-8 h-8 flex-shrink-0 text-primary-600"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -44,13 +44,16 @@ export function Header() {
                 d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
               />
             </svg>
-            <h1 className="text-xl font-bold text-gray-900 dark:text-white">
-              Job Application Tracker (React - NestJS - Drizzle)
+            <h1 className="text-xl font-bold text-gray-900 dark:text-white truncate">
+              Job Application Tracker{" "}
+              <span className="hidden sm:inline text-sm font-normal text-gray-500 dark:text-gray-400">
+                (React - NestJS - Drizzle)
+              </span>
             </h1>
           </Link>
 
           {/* Actions */}
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 flex-shrink-0">
             {/* Theme Toggle */}
             <button
               onClick={() => setIsDark(!isDark)}
@@ -91,7 +94,7 @@ export function Header() {
             {/* Add Application Button */}
             <Button onClick={() => navigate({ to: "/applications/new" })}>
               <svg
-                className="w-4 h-4 mr-2"
+                className="w-4 h-4 sm:mr-2"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -103,7 +106,7 @@ export function Header() {
                   d="M12 4v16m8-8H4"
                 />
               </svg>
-              Add Application
+              <span className="hidden sm:inline">Add Application</span>
             </Button>
           </div>
         </div>

--- a/tests/e2e/responsive-layout.spec.ts
+++ b/tests/e2e/responsive-layout.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+const VIEWPORTS = [
+  { name: 'iPhone SE', width: 375, height: 667 },
+  { name: 'iPhone 14', width: 393, height: 852 },
+  { name: 'iPad Mini', width: 768, height: 1024 },
+  { name: 'iPad Pro', width: 1024, height: 1366 },
+  { name: 'Desktop', width: 1440, height: 900 },
+];
+
+test.describe('Responsive layout', () => {
+  for (const viewport of VIEWPORTS) {
+    test(`action menu button is visible and not clipped at ${viewport.name} (${viewport.width}x${viewport.height})`, async ({
+      browser,
+    }) => {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+
+      await page.goto('/');
+      await page.waitForSelector('button[aria-label="Actions"]', {
+        timeout: 15000,
+      });
+
+      // Check the first action menu button is visible and within viewport
+      const actionsButton = page.locator('button[aria-label="Actions"]').first();
+      await expect(actionsButton).toBeVisible();
+
+      const box = await actionsButton.boundingBox();
+      expect(box).not.toBeNull();
+      // Button should be fully within the viewport (not clipped off-screen)
+      expect(box!.x).toBeGreaterThanOrEqual(0);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(viewport.width);
+      expect(box!.y).toBeGreaterThanOrEqual(0);
+
+      await context.close();
+    });
+  }
+
+  test('no horizontal scrollbar on mobile viewport', async ({ browser }) => {
+    const context = await browser.newContext({
+      viewport: { width: 375, height: 667 },
+    });
+    const page = await context.newPage();
+
+    await page.goto('/');
+    await page.waitForSelector('button[aria-label="Actions"]', {
+      timeout: 15000,
+    });
+
+    // Check that the document body does not overflow horizontally
+    const hasHorizontalScroll = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+    });
+    expect(hasHorizontalScroll).toBe(false);
+
+    await context.close();
+  });
+});


### PR DESCRIPTION
## Summary
- Set explicit `h-[38px]` on Import CSV, Export CSV, Template buttons and sort Select for consistent heights
- Fix mobile viewport overflow: cards no longer push wider than the screen
- Move action menu dropdown to fixed positioning so it's not clipped by `overflow-hidden` on cards
- Header: title truncates on narrow screens, "Add Application" becomes icon-only below `sm` breakpoint
- FilterBar: shorter button labels on mobile ("Import" vs "Import CSV"), flex-wrap for natural wrapping
- Filter selects go full-width below 480px

## Test Plan
- [x] All buttons and sort dropdown in filter bar row are the same height (desktop)
- [x] Action menu (3-dot) button visible at all viewport sizes (375px - 1440px)
- [x] No horizontal scrollbar on mobile (375px)
- [x] Action menu dropdown opens correctly with fixed positioning
- [x] All 42 e2e tests pass (including 6 new responsive layout tests)

---
Generated with [Claude Code](https://claude.ai/code)