### PR TITLE
chore: improve js-deps skill and add notifications docs

### DIFF
--- a/.agents/skills/js-deps/SKILL.md
+++ b/.agents/skills/js-deps/SKILL.md
@@ -2,8 +2,9 @@
 name: js-deps
 description: >
   Maintain JavaScript/Node.js packages through security audits or dependency updates on a dedicated branch.
-  Supports npm, yarn, pnpm, and bun. Use for: security audits, CVE fixes, vulnerability checks,
-  dependency updates, package upgrades, or when user types "/js-deps" with or without specific package names or glob patterns. Use "help" or "--help" to show update options.
+  Supports npm, yarn, pnpm, and bun. Use for: security audits, CVE fixes, vulnerability checks, dependency updates,
+  package upgrades, outdated packages, bump versions, fix npm vulnerabilities, modernize node_modules, or when user
+  types "/js-deps" with or without specific package names or glob patterns. Use "help" or "--help" to show options.
 license: MIT
 compatibility: Requires git, a JavaScript package manager (npm, yarn, pnpm, or bun), and network access to package registries
 metadata:

--- a/.agents/skills/js-deps/references/audit-workflow.md
+++ b/.agents/skills/js-deps/references/audit-workflow.md
@@ -44,7 +44,7 @@ $PM install <package>@latest  # npm
 $PM add <package>@latest      # yarn, pnpm, bun
 ```
 
-Validate after each update using available scripts from package.json (see SKILL.md step 7 for build/lint/test order). Continue on failure to collect all errors. If validation fails, revert to previous version before continuing.
+Validate after each update per SKILL.md step 7.
 
 ### Post-Audit Scan
 
@@ -94,9 +94,10 @@ Collect results from all agents before generating final report.
    ```bash
    git push -u origin "$BRANCH_NAME"
    ```
-4. Create PR using gh CLI:
+4. Create PR using gh CLI. Write the PR body to a temp file first (heredocs may fail in sandboxed environments):
    ```bash
-   gh pr create --title "fix: Security audit fixes" --body "$(cat <<'EOF'
+   BODY_FILE=$(mktemp)
+   cat > "$BODY_FILE" << 'PREOF'
    ## Summary
    - Vulnerabilities fixed: [count]
    - Remaining vulnerabilities: [count with reasons]
@@ -113,8 +114,9 @@ Collect results from all agents before generating final report.
    | Security Audit | X remaining |
 
    Generated with [Claude Code](https://claude.com/claude-code)
-   EOF
-   )"
+   PREOF
+   gh pr create --title "fix: Security audit fixes" --body-file "$BODY_FILE"
+   rm -f "$BODY_FILE"
    ```
 5. Return the PR URL to the user
 
@@ -132,4 +134,3 @@ When transitive dependencies have vulnerabilities that no direct dependency upda
 2. If so, add the advisory ID (e.g., `GHSA-xxxx-xxxx-xxxx`) to the `allowlist` array in each package's audit config
 3. Document the upstream blockers in the PR description — list which packages hold the vulnerable transitive dependency and why no fix is available
 4. Include the allowlist change in the same commit/PR as the fixable updates
-

--- a/.agents/skills/js-deps/references/update-workflow.md
+++ b/.agents/skills/js-deps/references/update-workflow.md
@@ -2,6 +2,10 @@
 
 Use the detected `$PM` package manager for all commands. See [package-managers.md](package-managers.md) for command mappings.
 
+## Prerequisites
+
+Ensure dependencies are installed first (SKILL.md step 5) so that `$PM outdated` can accurately compare installed vs. registry versions.
+
 ## Version Checking and Updates
 
 ### Check and Update Versions
@@ -43,9 +47,10 @@ Note: bun does not support audit. If using bun, skip this step.
    ```bash
    gh pr list --search "chore: Update dependencies" --state open
    ```
-4. Create PR using gh CLI:
+4. Create PR using gh CLI. Write the PR body to a temp file first (heredocs may fail in sandboxed environments):
    ```bash
-   gh pr create --title "chore: Update dependencies" --body "$(cat <<'EOF'
+   BODY_FILE=$(mktemp)
+   cat > "$BODY_FILE" << 'PREOF'
    ## Summary
    - Updated packages: [list major version changes]
    - Breaking changes fixed: [list code modifications]
@@ -62,8 +67,9 @@ Note: bun does not support audit. If using bun, skip this step.
    - [list modified package.json files]
 
    Generated with [Claude Code](https://claude.com/claude-code)
-   EOF
-   )"
+   PREOF
+   gh pr create --title "chore: Update dependencies" --body-file "$BODY_FILE"
+   rm -f "$BODY_FILE"
    ```
 5. Return the PR URL to the user
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "terminal-notifier -title \"Claude Code\" -message \"Claude needs your permission\" -sound Glass"
+            "command": "/opt/homebrew/bin/terminal-notifier -title \"Claude Code\" -message \"Claude needs your permission\" -sound Glass"
           }
         ]
       },
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "terminal-notifier -title \"Claude Code\" -message \"Claude has a question for you\" -sound Glass"
+            "command": "/opt/homebrew/bin/terminal-notifier -title \"Claude Code\" -message \"Claude has a question for you\" -sound Glass"
           }
         ]
       },
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "terminal-notifier -title \"Claude Code\" -message \"Claude is waiting for your input\" -sound Glass"
+            "command": "/opt/homebrew/bin/terminal-notifier -title \"Claude Code\" -message \"Claude is waiting for your input\" -sound Glass"
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -284,6 +284,16 @@ npx skills add -y whatifwedigdeeper/agent-skills
 
 See [.claude/](.claude/) for all available commands and skills.
 
+### Notifications (Optional)
+
+Claude Code hooks in `.claude/settings.json` send macOS notifications when Claude needs input (permission prompts, questions, idle). This requires [terminal-notifier](https://github.com/julienXX/terminal-notifier):
+
+```bash
+brew install terminal-notifier
+```
+
+No configuration needed — the hooks are already in `.claude/settings.json`. If you don't install it, hooks fail silently with no impact.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Expand js-deps skill description with more trigger keywords (outdated packages, bump versions, fix npm vulnerabilities, modernize node_modules) for better discoverability
- Switch PR body creation in audit and update workflows from heredocs to temp files, fixing failures in sandboxed environments
- Add prerequisites section to update workflow ensuring deps are installed before `outdated` check
- Use absolute path (`/opt/homebrew/bin/terminal-notifier`) in hook commands for reliability
- Document terminal-notifier notification setup in README

## Test Plan
- [ ] Verify js-deps skill triggers on expanded keywords
- [ ] Confirm terminal-notifier hooks fire with absolute path

---
Generated with [Claude Code](https://claude.com/claude-code)
