### PR TITLE
docs: comprehensive core specs audit — history, CSV, inline editing, unsubmitted status

### DIFF
--- a/specs/006-history-snapshots-svelte/spec.md
+++ b/specs/006-history-snapshots-svelte/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `006-history-snapshots-svelte`
 **Created**: 2026-02-15
-**Status**: Draft
+**Status**: Complete
 **Input**: Add version history and restore functionality to the Svelte+Hono stack, using a snapshot-based approach idiomatic to Drizzle's service-layer patterns.
 
 - [Context](#context)

--- a/specs/007-history-nextjs-express/spec.md
+++ b/specs/007-history-nextjs-express/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `007-history-nextjs-express`
 **Created**: 2026-02-15
-**Status**: Draft
+**Status**: Complete
 **Input**: Add version history and restore functionality to the Next.js+Express stack, using a snapshot-based approach matching the Hono implementation.
 
 - [Context](#context)

--- a/specs/008-history-react-koa/spec.md
+++ b/specs/008-history-react-koa/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `008-history-react-koa`
 **Created**: 2026-02-15
-**Status**: Draft
+**Status**: Complete
 **Input**: Add version history and restore functionality to the React-Koa stack, using a snapshot-based approach matching the Hono implementation.
 
 - [Context](#context)

--- a/specs/009-react-nestjs/spec.md
+++ b/specs/009-react-nestjs/spec.md
@@ -2,7 +2,7 @@
 
 - **Branch**: `009-react-nestjs`
 - **Created**: 2026-02-16
-- **Status**: In Progress
+- **Status**: Complete
 
 ## Overview
 

--- a/specs/010-nullable-date-applied/spec.md
+++ b/specs/010-nullable-date-applied/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Nullable Date Applied
 
 **Created**: 2026-02-16
-**Status**: Draft
+**Status**: Complete
 **Input**: User requirement: "Make dateApplied nullable — I frequently create application records before actually applying, so the date field shouldn't auto-fill with today's date"
 
 - [Clarifications](#clarifications)

--- a/specs/011-csv-import-export/spec.md
+++ b/specs/011-csv-import-export/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: CSV Import/Export
 
 **Created**: 2026-02-16
-**Status**: Draft
+**Status**: Complete
 **Depends on**: [010-nullable-date-applied](../010-nullable-date-applied/spec.md)
 **Input**: User requirement: "Add CSV import with duplicate detection on job posting URL, CSV export, and a downloadable sample template. Start with nest-api + tanstack-ui."
 

--- a/specs/012-unsubmitted-status/spec.md
+++ b/specs/012-unsubmitted-status/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Unsubmitted Default Status
 
 **Created**: 2026-02-17
-**Status**: Draft
+**Status**: Complete
 **Depends on**: [011-csv-import-export](../011-csv-import-export/spec.md)
 **Input**: User requirement: "Add a new 'unsubmitted' status as the default. When unsubmitted, dateApplied should be null and disabled."
 

--- a/specs/core/README.md
+++ b/specs/core/README.md
@@ -20,6 +20,10 @@ These specifications define **what** the application does without prescribing **
 - [003-offer-management.md](features/003-offer-management.md) - Manage offers and deadlines
 - [004-filtering-sorting.md](features/004-filtering-sorting.md) - Filter and sort the list
 - [005-archive-delete.md](features/005-archive-delete.md) - Archive and delete applications
+- [006-history.md](features/006-history.md) - Application change history and restore
+- [007-csv-import-export.md](features/007-csv-import-export.md) - CSV import and export
+- [008-inline-editing.md](features/008-inline-editing.md) - Inline field editing
+- [009-resizable-textareas.md](features/009-resizable-textareas.md) - Resizable textarea fields
 
 ### API Contract
 - [openapi.yaml](api/openapi.yaml) - RESTful API specification (OpenAPI 3.0)
@@ -74,9 +78,18 @@ Adapt UI specs for mobile patterns.
 This `core/` directory contains technology-agnostic specifications.
 
 The sibling directories contain technology-specific implementation details:
-- `001-job-application-tracker/` - React + Next.js + localStorage implementation
-- `002-dark-mode/` - Tailwind CSS dark mode implementation
+- `001-job-application-tracker/` - React + Next.js initial implementation
+- `002-dark-mode/` - Dark mode theme support
 - `003-express-api-prisma/` - Express + Prisma + PostgreSQL backend
+- `004-event-sourcing-undo-redo/` - Vue + Nuxt event sourcing
+- `005-inline-edit-*` - Inline editing implementations
+- `006-008-history-*` - History implementations per stack
+- `009-react-nestjs/` - React + TanStack + NestJS implementation
+- `010-nullable-date-applied/` - Nullable dateApplied
+- `011-csv-import-export/` - CSV import/export for NestJS
+- `012-unsubmitted-status/` - Unsubmitted default status
+- `013-resizable-textareas/` - Resizable textareas
+- `014-python-fastapi/` - Python FastAPI backend
 
 The core specs were extracted from these implementation specs to enable alternative implementations.
 
@@ -129,3 +142,6 @@ Optional for full completion:
 - Responsive design works on mobile
 - Dark mode supported
 - Accessibility requirements met
+- History panel with restore functionality
+- CSV import/export
+- Inline editing (alternative to modal)

--- a/specs/core/api/openapi.yaml
+++ b/specs/core/api/openapi.yaml
@@ -34,6 +34,10 @@ tags:
     description: Interview progress tracking
   - name: System
     description: Health and status
+  - name: History
+    description: Application change history and restore
+  - name: Import/Export
+    description: CSV import and export
 
 paths:
   /health:
@@ -103,7 +107,7 @@ paths:
           schema:
             type: string
             enum: [dateApplied, companyName, updatedAt]
-            default: dateApplied
+            default: updatedAt
         - name: sortDir
           in: query
           description: Sort direction
@@ -409,6 +413,132 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /applications/{id}/history:
+    parameters:
+      - $ref: '#/components/parameters/ApplicationId'
+
+    get:
+      tags: [History]
+      summary: Get application history
+      description: Returns chronological list of snapshots for an application, newest first
+      operationId: getApplicationHistory
+      responses:
+        '200':
+          description: List of history entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HistoryEntry'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /applications/{id}/history/{historyId}/restore:
+    parameters:
+      - $ref: '#/components/parameters/ApplicationId'
+      - name: historyId
+        in: path
+        required: true
+        description: History entry UUID
+        schema:
+          type: string
+          format: uuid
+
+    post:
+      tags: [History]
+      summary: Restore to historical version
+      description: Restores the application to the state captured in the specified history entry
+      operationId: restoreApplicationVersion
+      responses:
+        '200':
+          description: Application restored to historical state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Application'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /applications/import:
+    post:
+      tags: [Import/Export]
+      summary: Import applications from CSV
+      description: |
+        Uploads a CSV file and creates applications for each valid row.
+        Rows are processed independently - partial success is possible.
+        Duplicate detection uses jobPostingUrl.
+      operationId: importApplicationsCsv
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: CSV file with application data
+      responses:
+        '200':
+          description: Import results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /applications/export:
+    get:
+      tags: [Import/Export]
+      summary: Export applications as CSV
+      description: Downloads all applications (including archived) as a CSV file
+      operationId: exportApplicationsCsv
+      responses:
+        '200':
+          description: CSV file download
+          content:
+            text/csv:
+              schema:
+                type: string
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+              description: 'attachment; filename="applications-YYYY-MM-DD.csv"'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /applications/sample-csv:
+    get:
+      tags: [Import/Export]
+      summary: Download CSV template
+      description: Downloads a CSV template with headers and one example row
+      operationId: getSampleCsv
+      responses:
+        '200':
+          description: CSV template download
+          content:
+            text/csv:
+              schema:
+                type: string
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+              description: 'attachment; filename="application-tracker-template.csv"'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
 components:
   parameters:
     ApplicationId:
@@ -518,7 +648,6 @@ components:
         - id
         - companyName
         - positionTitle
-        - dateApplied
         - status
         - createdAt
         - updatedAt
@@ -537,6 +666,7 @@ components:
         dateApplied:
           type: string
           format: date
+          nullable: true
         status:
           $ref: '#/components/schemas/ApplicationStatus'
         createdAt:
@@ -628,6 +758,7 @@ components:
     ApplicationStatus:
       type: string
       enum:
+        - unsubmitted
         - applied
         - rejected
         - interviewing
@@ -687,6 +818,7 @@ components:
         dateApplied:
           type: string
           format: date
+          nullable: true
         companyUrl:
           type: string
           format: uri
@@ -733,6 +865,7 @@ components:
         dateApplied:
           type: string
           format: date
+          nullable: true
         status:
           $ref: '#/components/schemas/ApplicationStatus'
         companyUrl:
@@ -830,3 +963,50 @@ components:
           minimum: 1
           maximum: 5
           nullable: true
+
+    HistoryEntry:
+      type: object
+      required: [id, applicationId, sequenceNumber, snapshot, description, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        applicationId:
+          type: string
+          format: uuid
+        sequenceNumber:
+          type: integer
+          description: Monotonically increasing per application
+        snapshot:
+          type: object
+          description: Full application state at this point in time
+        description:
+          type: string
+          description: Human-readable change summary
+        createdAt:
+          type: string
+          format: date-time
+
+    ImportResult:
+      type: object
+      required: [imported, skipped, errors]
+      properties:
+        imported:
+          type: integer
+          description: Number of successfully imported applications
+        skipped:
+          type: integer
+          description: Number of rows skipped (duplicates)
+        errors:
+          type: array
+          description: Per-row error details
+          items:
+            type: object
+            required: [row, message]
+            properties:
+              row:
+                type: integer
+                description: 1-indexed row number in the CSV
+              message:
+                type: string
+                description: Error description

--- a/specs/core/domain/entities.md
+++ b/specs/core/domain/entities.md
@@ -15,8 +15,8 @@ A record representing a single job application submitted by the user.
 | id | UUID | auto-generated | - | Unique identifier |
 | companyName | string | yes | - | 1-200 characters, non-empty |
 | positionTitle | string | yes | - | 1-200 characters, non-empty |
-| dateApplied | date | yes | creation date | Any valid date |
-| status | ApplicationStatus | yes | "applied" | See [enums.md](enums.md) |
+| dateApplied | date | no | null | Any valid date, or null |
+| status | ApplicationStatus | yes | "unsubmitted" | See [enums.md](enums.md) |
 | createdAt | datetime | auto-generated | creation time | Immutable after creation |
 | updatedAt | datetime | auto-generated | creation time | Updated on any change |
 | companyUrl | URL | no | - | Valid URL format |
@@ -71,6 +71,27 @@ Represents one step in the interview process for a job application.
 
 ---
 
+## ApplicationSnapshot
+
+Represents a point-in-time capture of an application's state, used for history tracking.
+
+### Properties
+
+| Property | Type | Required | Default | Constraints |
+|----------|------|----------|---------|-------------|
+| id | UUID | auto-generated | - | Unique identifier |
+| applicationId | UUID | yes | - | References JobApplication |
+| sequenceNumber | integer | auto-generated | - | Monotonically increasing per application |
+| snapshot | object | yes | - | Full JobApplication state at this point in time |
+| description | string | yes | - | Human-readable change summary (e.g., "Status changed from applied to interviewing") |
+| createdAt | datetime | auto-generated | creation time | Immutable after creation |
+
+### Relationships
+
+- **Belongs to** JobApplication
+
+---
+
 ## Default Interview Stages
 
 When a JobApplication transitions to "interviewing" status, the following default stages are created (if no stages exist):
@@ -92,7 +113,7 @@ Users may customize these stages (add, remove, reorder) for individual applicati
 
 ### JobApplication
 
-1. **Created** with required fields (companyName, positionTitle)
+1. **Created** with required fields (companyName, positionTitle); defaults to unsubmitted status with null dateApplied
 2. **Updated** as user adds details, changes status
 3. **Archived** (soft delete) - hidden from default views but retrievable
 4. **Restored** from archive to active state
@@ -104,3 +125,10 @@ Users may customize these stages (add, remove, reorder) for individual applicati
 2. **Updated** to mark completion, add notes/ratings
 3. **Reordered** within the parent application
 4. **Deleted** when no longer relevant
+
+### ApplicationSnapshot
+
+1. **Created** automatically on every application mutation (create, update, status change)
+2. **Read** to display history timeline and field-level diffs
+3. **Used for restore** - snapshot data written back to parent application
+4. **Deleted** when parent application is deleted (cascade)

--- a/specs/core/domain/enums.md
+++ b/specs/core/domain/enums.md
@@ -10,6 +10,7 @@ The current state of a job application in the hiring pipeline.
 
 | Value | Display Name | Description |
 |-------|--------------|-------------|
+| `unsubmitted` | Unsubmitted | Application saved as draft, not yet submitted |
 | `applied` | Applied | Application submitted, awaiting response |
 | `rejected` | Rejected | Application was rejected |
 | `interviewing` | Interviewing | Active interview process |
@@ -27,6 +28,7 @@ For filtering and display purposes, statuses can be grouped:
 | Active | applied, interviewing, given offer |
 | Closed - Positive | accepted offer |
 | Closed - Negative | rejected, declined offer, no offer |
+| Draft | unsubmitted |
 | Terminal | accepted offer, declined offer |
 
 ---
@@ -121,6 +123,8 @@ Available fields for sorting application lists.
 | `companyName` | Company Name | Alphabetical by company |
 | `status` | Status | Grouped by application status |
 | `updatedAt` | Last Updated | Most recently modified |
+
+**Default sort**: `updatedAt` descending. When sorting by `dateApplied`, null values sort last regardless of direction.
 
 ## Sort Directions
 

--- a/specs/core/domain/state-transitions.md
+++ b/specs/core/domain/state-transitions.md
@@ -9,18 +9,23 @@ This document defines the valid state transitions for domain entities and their 
 ### State Diagram
 
 ```
-                         ┌─────────────┐
-                         │   applied   │ (initial state)
-                         └──────┬──────┘
-                                │
-               ┌────────────────┼────────────────┐
-               ▼                ▼                ▼
-        ┌─────────────┐  ┌───────────┐    ┌───────────┐
-        │interviewing │  │ rejected  │    │  (any)    │
-        └──────┬──────┘  └───────────┘    │ archived  │
-               │                          └───────────┘
-       ┌───────┼───────────┐
-       ▼       ▼           ▼
+                       ┌───────────────┐
+                       │ unsubmitted  │ (initial state)
+                       └──────┬────────┘
+                              │
+                              ▼
+                       ┌─────────────┐
+                       │   applied   │
+                       └──────┬──────┘
+                              │
+             ┌────────────────┼────────────────┐
+             ▼                ▼                ▼
+      ┌─────────────┐  ┌───────────┐    ┌───────────┐
+      │interviewing │  │ rejected  │    │  (any)    │
+      └──────┬──────┘  └───────────┘    │ archived  │
+             │                          └───────────┘
+     ┌───────┼───────────┐
+     ▼       ▼           ▼
 ┌─────────────┐ ┌─────────┐ ┌─────────┐
 │ given offer │ │no offer │ │ applied │ (revert)
 └─────┬───────┘ └─────────┘ └─────────┘
@@ -37,6 +42,11 @@ This document defines the valid state transitions for domain entities and their 
 
 | From | To | Allowed | Side Effects |
 |------|-----|---------|--------------|
+| unsubmitted | applied | Yes | Auto-populate dateApplied with today if null |
+| unsubmitted | interviewing | Yes | Auto-populate dateApplied; create default stages if none |
+| unsubmitted | rejected | Yes | Auto-populate dateApplied with today if null |
+| unsubmitted | given offer | Yes | Auto-populate dateApplied with today if null |
+| (any non-terminal) | unsubmitted | Yes | Clear dateApplied to null |
 | applied | rejected | Yes | None |
 | applied | interviewing | Yes | Create default interview stages if none exist |
 | applied | given offer | Yes | None (rare: direct offer) |
@@ -56,6 +66,21 @@ This document defines the valid state transitions for domain entities and their 
 | no offer | interviewing | Yes | New interview process |
 
 ### Side Effects Detail
+
+#### Transition: unsubmitted → (any status)
+
+When an application moves away from "unsubmitted":
+
+1. **Check** if dateApplied is null
+2. **If null**, auto-populate with today's date
+3. **If already set**, preserve existing value
+
+#### Transition: (any) → unsubmitted
+
+When an application reverts to "unsubmitted":
+
+1. **Clear** dateApplied to null
+2. Preserve all other application data
 
 #### Transition: applied → interviewing
 

--- a/specs/core/domain/validation-rules.md
+++ b/specs/core/domain/validation-rules.md
@@ -45,6 +45,8 @@ This document defines validation rules for domain entities, independent of any v
 | Rule | Error Message |
 |------|---------------|
 | If both salaryMin and salaryMax provided, salaryMin <= salaryMax | "Minimum salary cannot exceed maximum salary" |
+| If status is "unsubmitted", dateApplied must be null | "Date applied must be empty when status is unsubmitted" |
+| If status is not "unsubmitted" and dateApplied transitions from null, auto-populate with today | (Auto-correction, not error) |
 
 ### Enum Validation
 
@@ -58,7 +60,7 @@ This document defines validation rules for domain entities, independent of any v
 
 | Field | Rule | Error Message |
 |-------|------|---------------|
-| dateApplied | Must be valid date format | "Invalid date format" |
+| dateApplied | If provided, must be valid date format. May be null. | "Invalid date format" |
 | offerDueDate | If provided, must be valid date format | "Invalid offer due date format" |
 
 ---
@@ -105,6 +107,7 @@ This document defines validation rules for domain entities, independent of any v
 
 - All required field validations apply
 - Default values are applied before validation where specified
+- Default status is `unsubmitted` with `dateApplied` as null
 - Invalid input prevents creation and returns validation errors
 
 ### On Update (Partial)

--- a/specs/core/features/001-application-management.md
+++ b/specs/core/features/001-application-management.md
@@ -28,7 +28,7 @@ Users need to record job applications they submit, capturing essential details l
 
 2. **Given** I am filling out the new application form
    **When** I enter a company name and position title and submit
-   **Then** the application is created with status "applied" and today's date
+   **Then** the application is created with status "unsubmitted" and no date applied
 
 3. **Given** I am filling out the new application form
    **When** I leave required fields empty and submit
@@ -145,8 +145,8 @@ Process:
   1. Validate required fields present and valid
   2. Validate optional fields if provided
   3. Generate unique ID
-  4. Set dateApplied to today if not provided
-  5. Set status to "applied"
+  4. Leave dateApplied as null if not provided
+  5. Set status to "unsubmitted"
   6. Set createdAt and updatedAt to now
   7. Set isArchived to false
   8. Initialize interviewStages to empty array

--- a/specs/core/features/006-history.md
+++ b/specs/core/features/006-history.md
@@ -1,0 +1,189 @@
+# Feature: Application History
+
+Track how an application has changed over time and optionally restore to a previous state.
+
+**Priority**: P2 (Important)
+
+---
+
+## Overview
+
+As users update applications throughout their job search, they need visibility into what changed and when. Every mutation (create, update, status change) creates a snapshot capturing the full application state at that moment. Users can browse a timeline of changes, inspect field-level diffs, and restore to any previous version.
+
+---
+
+## User Stories
+
+### US-6.1: View Change History
+
+**As a** job seeker
+**I want to** see a timeline of changes to an application
+**So that** I can understand how my application has evolved
+
+#### Acceptance Criteria
+
+1. **Given** I am viewing an application
+   **When** I open the history panel
+   **Then** I see a timeline of all past changes, newest first
+
+2. **Given** I am viewing the history panel
+   **When** I look at an entry
+   **Then** I see a human-readable description and a relative timestamp (e.g., "2 hours ago")
+
+3. **Given** I am viewing the history panel
+   **When** the panel opens
+   **Then** it slides in from the right side of the screen
+
+---
+
+### US-6.2: View Field-Level Diffs
+
+**As a** job seeker
+**I want to** see exactly what changed in each update
+**So that** I can review specific modifications
+
+#### Acceptance Criteria
+
+1. **Given** I am viewing the history panel
+   **When** I click on a history entry
+   **Then** it expands to show field-level diffs
+
+2. **Given** I am viewing an expanded history entry
+   **When** fields have changed
+   **Then** old values are shown struck-through/red and new values in green
+
+3. **Given** I am viewing an expanded history entry
+   **When** the diff is computed
+   **Then** only changed fields are shown (unchanged fields are hidden)
+
+4. **Given** the first history entry (initial creation)
+   **When** I expand it
+   **Then** no diffs are shown (there is no previous snapshot to compare against)
+
+---
+
+### US-6.3: Restore to Previous Version
+
+**As a** job seeker
+**I want to** revert an application to a previous state
+**So that** I can undo unwanted changes
+
+#### Acceptance Criteria
+
+1. **Given** I am viewing a non-current history entry
+   **When** I look at its actions
+   **Then** I see a "Restore to this point" button
+
+2. **Given** I click "Restore to this point"
+   **When** I confirm the action
+   **Then** the application is updated to match that snapshot's state
+
+3. **Given** I have restored to a previous version
+   **When** the restore completes
+   **Then** a new history entry is created with the description "Restored to version N"
+
+4. **Given** I am viewing the most recent (current) history entry
+   **When** I look at its actions
+   **Then** there is no restore button (already at this version)
+
+---
+
+## Behaviors
+
+### Record Snapshot
+
+```
+Input: { applicationId, description }
+Process:
+  1. Load current application state (all fields + interview stages)
+  2. Capture full state as a JSON snapshot
+  3. Generate human-readable description (e.g., "Status changed to Interviewing")
+  4. Persist as ApplicationSnapshot with:
+     - snapshotId (generated)
+     - applicationId
+     - data (full application state)
+     - description
+     - createdAt (now)
+Output: Created snapshot
+```
+
+### Compute Diffs
+
+```
+Input: { currentSnapshot, previousSnapshot }
+Process:
+  1. If previousSnapshot is null, return empty diffs (first entry)
+  2. Compare each field in currentSnapshot.data vs previousSnapshot.data
+  3. For each field where values differ:
+     - Record { field, oldValue, newValue }
+  4. Ignore metadata fields (updatedAt, id)
+Output: Array of { field, oldValue, newValue }
+```
+
+### Restore Version
+
+```
+Input: { applicationId, snapshotId }
+Process:
+  1. Find application (error if not found)
+  2. Find snapshot (error if not found or wrong application)
+  3. Load snapshot data
+  4. Compare snapshot data to current application state
+  5. If identical, return current application (no-op)
+  6. Write snapshot field values back to application
+  7. Sync interview stages (delete removed, add new, update changed)
+  8. Record new snapshot with description "Restored to version N"
+Output: Updated application
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| First snapshot (creation) | No diffs available; description is "Application created" |
+| Restore with changed interview stages | Stages are fully replaced with snapshot's stage data |
+| Delete application | All history snapshots cascade-deleted |
+| Concurrent edits | Last write wins; both edits produce separate snapshots |
+| Restore to current state | No-op; no new snapshot created |
+| Snapshot references deleted stage | Stage is recreated from snapshot data on restore |
+| Very long history | Paginate or lazy-load entries; newest first |
+
+---
+
+## Display Requirements
+
+### History Panel
+
+- Slide-in panel from the right side
+- Timeline layout with entries listed newest-first
+- Each entry shows: description, relative timestamp
+- Expandable entries to reveal field-level diffs
+- Close button to dismiss panel
+
+### Diff Display
+
+- Changed fields shown as labeled rows
+- Old value: struck-through text, red/muted styling
+- New value: green/highlighted styling
+- Only changed fields displayed
+
+### Restore Controls
+
+- "Restore to this point" button on non-current entries
+- Confirmation dialog before restore
+- Success notification after restore completes
+
+---
+
+## API Operations
+
+| Operation | Method | Endpoint | Request | Response |
+|-----------|--------|----------|---------|----------|
+| Get History | GET | /applications/{id}/history | - | Array of HistoryEntry |
+| Restore Version | POST | /applications/{id}/history/{historyId}/restore | - | Updated application |
+
+Note: Snapshots are created automatically by the server on every mutation. There is no explicit "create snapshot" endpoint.
+
+See [openapi.yaml](../api/openapi.yaml) for full API specification.

--- a/specs/core/features/007-csv-import-export.md
+++ b/specs/core/features/007-csv-import-export.md
@@ -1,0 +1,238 @@
+# Feature: CSV Import/Export
+
+Bulk-create applications from a CSV file, export all applications as CSV, and download a template.
+
+**Priority**: P2 (Important)
+
+---
+
+## Overview
+
+Job seekers who track applications in spreadsheets or other tools need a way to migrate their data into the system. Similarly, users may want to export their data for backup or external analysis. This feature provides CSV-based import, export, and a downloadable template with the correct column format.
+
+---
+
+## User Stories
+
+### US-7.1: Import from CSV
+
+**As a** job seeker
+**I want to** upload a CSV file to create multiple applications at once
+**So that** I can migrate existing data without manual entry
+
+#### Acceptance Criteria
+
+1. **Given** I want to import applications
+   **When** I select a .csv file
+   **Then** the system processes each row independently
+
+2. **Given** the import has completed
+   **When** I view the results
+   **Then** I see counts of imported, skipped, and errored rows
+
+3. **Given** a row fails validation
+   **When** I view the error details
+   **Then** I see the row number and a descriptive error message
+
+4. **Given** a row is successfully imported
+   **When** the application is created
+   **Then** an initial history snapshot is recorded for that application
+
+---
+
+### US-7.2: Export to CSV
+
+**As a** job seeker
+**I want to** download all my applications as a CSV file
+**So that** I can back up my data or analyze it externally
+
+#### Acceptance Criteria
+
+1. **Given** I want to export my applications
+   **When** I trigger the export
+   **Then** a file named `applications-YYYY-MM-DD.csv` is downloaded
+
+2. **Given** I have both active and archived applications
+   **When** I export
+   **Then** all applications are included regardless of archive status
+
+3. **Given** the export completes
+   **When** I open the file
+   **Then** it contains 16 columns matching the CSV format specification
+
+4. **Given** an application has interview stages
+   **When** it is exported
+   **Then** interview stages are excluded from the CSV (application fields only)
+
+---
+
+### US-7.3: Download Template
+
+**As a** job seeker
+**I want to** download a CSV template with the correct headers
+**So that** I can fill in my data in the right format before importing
+
+#### Acceptance Criteria
+
+1. **Given** I want to prepare data for import
+   **When** I download the template
+   **Then** I receive a CSV file with all 16 column headers
+
+2. **Given** I have downloaded the template
+   **When** I open it
+   **Then** it includes one example row with realistic sample data
+
+---
+
+### US-7.4: Duplicate Detection
+
+**As a** job seeker
+**I want to** avoid creating duplicate applications during import
+**So that** my data stays clean
+
+#### Acceptance Criteria
+
+1. **Given** I am importing a CSV
+   **When** a row's jobPostingUrl matches an existing application (including archived)
+   **Then** that row is skipped (not counted as an error)
+
+2. **Given** I am importing a CSV
+   **When** two rows in the same file share the same jobPostingUrl
+   **Then** the first row is imported and subsequent duplicates are skipped
+
+3. **Given** the import has completed with skipped rows
+   **When** I view the results
+   **Then** the skipped count includes all duplicates (both existing and intra-file)
+
+---
+
+## CSV Format
+
+16 columns in the following order:
+
+| Column | Required | Type | Notes |
+|--------|----------|------|-------|
+| companyName | Yes | string | |
+| positionTitle | Yes | string | |
+| dateApplied | Yes | date | YYYY-MM-DD format |
+| status | No | enum | Default: "applied" |
+| companyUrl | No | string | URL |
+| jobPostingUrl | No | string | URL; used for duplicate detection |
+| companyCareerUrl | No | string | URL |
+| companyCategory | No | string | |
+| skillsMatch | No | string | |
+| jobSource | No | string | |
+| coverLetterRequired | No | boolean | true/false |
+| specialRequirements | No | string | |
+| salaryMin | No | number | |
+| salaryMax | No | number | |
+| notes | No | string | |
+| offerDueDate | No | date | YYYY-MM-DD format |
+
+---
+
+## Behaviors
+
+### Import from CSV
+
+```
+Input: { file (CSV) }
+Process:
+  1. Parse CSV headers
+  2. Validate required columns present (companyName, positionTitle, dateApplied)
+  3. If required columns missing, return error immediately
+  4. Initialize counters: imported=0, skipped=0, errors=[]
+  5. Collect all jobPostingUrls from existing applications
+  6. Initialize seenUrls set for intra-file dedup
+  7. For each row:
+     a. Validate required fields present
+     b. Validate field formats (dates, enums, numbers)
+     c. If jobPostingUrl exists and is in existing apps or seenUrls → skip, increment skipped
+     d. If validation fails → add to errors with row number and message
+     e. Otherwise → create application, record initial snapshot
+     f. Add jobPostingUrl to seenUrls (if present)
+     g. Increment imported
+  8. Return { imported, skipped, errors }
+Output: ImportResult { imported: number, skipped: number, errors: Array<{ row: number, message: string }> }
+```
+
+### Export to CSV
+
+```
+Input: (none)
+Process:
+  1. Query all applications (active + archived)
+  2. Order by dateApplied descending
+  3. Format each application as a CSV row (16 columns)
+  4. Prepend header row
+  5. Return as text/csv with filename applications-YYYY-MM-DD.csv
+Output: CSV file
+```
+
+### Download Template
+
+```
+Input: (none)
+Process:
+  1. Generate header row with all 16 column names
+  2. Generate example row with sample data:
+     - "Acme Corp", "Software Engineer", "2026-01-15", "applied",
+       "https://acme.com", "https://acme.com/jobs/123", "https://acme.com/careers",
+       "Tech", "React, TypeScript", "LinkedIn", "false",
+       "Must have US work authorization", "120000", "150000",
+       "Referred by Jane", ""
+  3. Return as text/csv
+Output: CSV file
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Empty file (no data rows) | Return imported=0, skipped=0, errors=[] |
+| Missing required columns | Reject entire file with error listing missing columns |
+| Extra columns beyond 16 | Ignore extra columns silently |
+| Round-trip (export then import) | Produces identical applications (format is compatible) |
+| Very large file (1000+ rows) | Process all rows; no artificial limit |
+| Invalid enum value in status column | Row-level error (e.g., "Row 5: invalid status 'pending'") |
+| Row with empty required field | Row-level error (e.g., "Row 3: companyName is required") |
+| CSV with different column order | Match by header name, not position |
+| Quoted fields with commas | Standard CSV parsing (RFC 4180) |
+| jobPostingUrl is empty | No duplicate check for that row; import normally |
+
+---
+
+## Display Requirements
+
+### Import UI
+
+- File picker accepting .csv files
+- Upload button to trigger import
+- Results summary: "Imported: X, Skipped: Y, Errors: Z"
+- Expandable error list with row numbers and messages
+- Success state returns user to applications list
+
+### Export UI
+
+- Export button in applications list toolbar
+- Triggers immediate file download
+- No configuration needed
+
+### Template UI
+
+- "Download Template" link near import controls
+- Triggers immediate file download
+
+---
+
+## API Operations
+
+| Operation | Method | Endpoint | Request | Response |
+|-----------|--------|----------|---------|----------|
+| Import | POST | /applications/import | multipart/form-data (CSV file) | ImportResult |
+| Export | GET | /applications/export | - | text/csv |
+| Template | GET | /applications/sample-csv | - | text/csv |
+
+See [openapi.yaml](../api/openapi.yaml) for full API specification.

--- a/specs/core/features/008-inline-editing.md
+++ b/specs/core/features/008-inline-editing.md
@@ -1,0 +1,155 @@
+# Feature: Inline Editing
+
+Edit application fields directly on the detail page without a separate modal or form.
+
+**Priority**: P3 (Nice to Have)
+
+---
+
+## Overview
+
+Instead of navigating to a separate edit form or opening a modal, the application detail page is always in edit mode. All fields are directly editable in place, with changes saved on blur or via an explicit save button. This reduces friction for quick updates and keeps the user in context.
+
+> **Note**: Currently implemented in vue-ui only. This spec defines the target behavior for all stacks. Stacks without inline editing use a separate edit form/modal (see [001-application-management](001-application-management.md)).
+
+---
+
+## User Stories
+
+### US-8.1: Edit Fields In-Place
+
+**As a** job seeker
+**I want to** edit any field directly on the application detail page
+**So that** I can make quick updates without navigating to a separate form
+
+#### Acceptance Criteria
+
+1. **Given** I am viewing an application detail page
+   **When** I look at text fields (company name, position, notes, etc.)
+   **Then** they are rendered as editable input or textarea elements
+
+2. **Given** I am viewing an application detail page
+   **When** I look at enum fields (status, cover letter required, etc.)
+   **Then** they are rendered as dropdown/select elements
+
+3. **Given** I have modified a field
+   **When** I blur the field or click save
+   **Then** the change is persisted to the server
+
+4. **Given** I enter an invalid value
+   **When** validation runs
+   **Then** I see an inline error message next to the field
+
+---
+
+### US-8.2: Unsaved Changes Warning
+
+**As a** job seeker
+**I want to** be warned before losing unsaved changes
+**So that** I don't accidentally discard edits
+
+#### Acceptance Criteria
+
+1. **Given** I have unsaved changes on the detail page
+   **When** I attempt to navigate away (browser back, link click, route change)
+   **Then** a confirmation dialog appears
+
+2. **Given** the confirmation dialog is showing
+   **When** I choose to discard
+   **Then** navigation proceeds and changes are lost
+
+3. **Given** the confirmation dialog is showing
+   **When** I choose to save
+   **Then** changes are saved and navigation proceeds
+
+4. **Given** I have no unsaved changes
+   **When** I navigate away
+   **Then** no dialog appears
+
+---
+
+## Behaviors
+
+### Field Edit
+
+```
+Input: { applicationId, fieldName, newValue }
+Process:
+  1. Validate new value against field constraints
+  2. If invalid, show inline error and stop
+  3. Mark form as dirty (unsaved changes exist)
+  4. On blur or explicit save:
+     a. Send PATCH request with changed fields
+     b. On success, mark form as clean
+     c. On failure, show error notification and keep dirty state
+Output: Updated application (on save)
+```
+
+### Navigation Guard
+
+```
+Input: { isDirty, navigationTarget }
+Process:
+  1. Check if form has unsaved changes (isDirty)
+  2. If clean, allow navigation immediately
+  3. If dirty, show confirmation dialog:
+     - "You have unsaved changes. Save before leaving?"
+     - Options: Save, Discard, Cancel
+  4. On Save: persist changes, then navigate
+  5. On Discard: reset form, then navigate
+  6. On Cancel: stay on current page
+Output: Navigation allowed or blocked
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Concurrent edits (another user/tab) | Last write wins; no conflict detection required |
+| Network error during save | Show error notification; keep dirty state so user can retry |
+| Rapid field changes (typing fast) | Debounce saves; only send after user stops typing or blurs |
+| Navigate during in-flight save | Wait for save to complete before navigating |
+| Browser refresh with unsaved changes | Browser's native beforeunload dialog shown |
+| Save with no actual changes | No-op; do not send request if values unchanged |
+| Read-only fields (id, createdAt) | Not editable; displayed as plain text |
+
+---
+
+## Display Requirements
+
+### Field Rendering
+
+- Text fields: `<input>` elements with subtle border/underline styling
+- Long text fields (notes, specialRequirements): `<textarea>` elements
+- Enum fields (status): `<select>` dropdowns
+- Date fields: date picker inputs
+- Boolean fields (coverLetterRequired): checkbox or toggle
+- Number fields (salaryMin, salaryMax): number inputs
+
+### Validation Display
+
+- Inline error messages below the invalid field
+- Red border or highlight on invalid fields
+- Errors clear when the field is corrected
+
+### Save Controls
+
+- Optional explicit "Save" button for users who prefer manual save
+- Visual indicator showing unsaved changes exist (e.g., dot or badge)
+- Success feedback on save (brief notification or check mark)
+
+---
+
+## API Operations
+
+Uses the existing application update endpoint:
+
+| Operation | Method | Endpoint | Request | Response |
+|-----------|--------|----------|---------|----------|
+| Update Fields | PATCH | /applications/{id} | Partial application data | Updated application |
+
+No new endpoints required. Inline editing uses the same PATCH endpoint as the modal-based edit flow.
+
+See [openapi.yaml](../api/openapi.yaml) for full API specification.

--- a/specs/core/features/009-resizable-textareas.md
+++ b/specs/core/features/009-resizable-textareas.md
@@ -1,0 +1,132 @@
+# Feature: Resizable Textareas
+
+Allow users to vertically resize textarea fields with persisted height across page reloads.
+
+**Priority**: P3 (Nice to Have)
+
+---
+
+## Overview
+
+Textarea fields vary in how much content users write. Some users write detailed notes while others keep them brief. This feature lets users drag a resize handle to adjust textarea height, and remembers their preference via localStorage so the height is restored on subsequent visits.
+
+---
+
+## User Stories
+
+### US-9.1: Resize Textarea
+
+**As a** job seeker
+**I want to** resize textarea fields by dragging a handle
+**So that** I can see more or less content as needed
+
+#### Acceptance Criteria
+
+1. **Given** I am viewing a textarea field
+   **When** I drag the resize handle
+   **Then** the textarea height changes accordingly
+
+2. **Given** I am resizing a textarea
+   **When** I drag
+   **Then** only the vertical dimension changes (horizontal width stays fixed)
+
+3. **Given** I am on an application form or detail page
+   **When** I look at the specialRequirements, notes, and interview stage notes fields
+   **Then** each has a visible resize handle
+
+---
+
+### US-9.2: Persist Height
+
+**As a** job seeker
+**I want to** have my resized textarea heights remembered
+**So that** I don't have to resize every time I visit the page
+
+#### Acceptance Criteria
+
+1. **Given** I have resized a textarea
+   **When** I reload the page
+   **Then** the textarea returns to my previously set height
+
+2. **Given** the height is persisted
+   **When** I check storage
+   **Then** it is saved to localStorage keyed by field identifier (e.g., `textarea-height-notes`)
+
+3. **Given** no saved height exists for a field
+   **When** the textarea renders
+   **Then** the default height is used
+
+---
+
+## Behaviors
+
+### Resize Textarea
+
+```
+Input: { fieldId, newHeight (from resize event) }
+Process:
+  1. User drags the native browser resize handle
+  2. On resize event (or ResizeObserver callback):
+     a. Read the new height of the textarea element
+     b. Construct storage key: "textarea-height-{fieldId}"
+     c. Save height to localStorage: localStorage.setItem(key, newHeight)
+Output: Height saved to localStorage
+```
+
+### Restore Height on Mount
+
+```
+Input: { fieldId }
+Process:
+  1. On component mount, construct storage key: "textarea-height-{fieldId}"
+  2. Read saved height: localStorage.getItem(key)
+  3. If saved height exists:
+     a. Validate it is a positive number
+     b. Cap at viewport height if larger
+     c. Apply as inline style: element.style.height = savedHeight + "px"
+  4. If no saved height, use CSS default height
+Output: Textarea rendered at saved or default height
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| localStorage unavailable (private browsing, disabled) | Use default height; resize still works but is not persisted |
+| Saved height larger than viewport | Cap at viewport height minus reasonable margin |
+| Saved height is zero or negative | Ignore saved value; use default height |
+| Clearing browser data | Heights reset to defaults (expected behavior) |
+| Multiple textareas on same page | Each has independent key (e.g., `textarea-height-notes`, `textarea-height-specialRequirements`) |
+| Interview stage notes (multiple stages) | Key includes stage identifier (e.g., `textarea-height-stage-{stageId}-notes`) |
+| Window resize makes saved height too large | No automatic adjustment; user can re-resize |
+
+---
+
+## Display Requirements
+
+### Resize Handle
+
+- Use the browser's native textarea resize handle (`resize: vertical` CSS)
+- No custom drag handle needed
+- Cursor changes to resize cursor on hover over handle
+
+### Textarea Styling
+
+- Consistent minimum height across all textareas (e.g., 80px)
+- No maximum height constraint (user controls size)
+- Smooth visual feedback during resize
+
+---
+
+## API Operations
+
+No API operations required. This feature is entirely client-side using localStorage for persistence.
+
+| Aspect | Details |
+|--------|---------|
+| Storage mechanism | localStorage |
+| Key format | `textarea-height-{fieldId}` |
+| Value format | Height in pixels (number as string) |
+| Fallback | CSS default height when no stored value |

--- a/specs/core/ui/components.md
+++ b/specs/core/ui/components.md
@@ -21,6 +21,8 @@ This document defines reusable UI components and their behaviors, independent of
 | ConfirmDialog | Confirmation modal |
 | EmptyState | No data placeholder |
 | Pagination | Page navigation |
+| HistoryPanel | Sliding panel showing application change timeline |
+| ImportModal | CSV file upload dialog with results display |
 
 ---
 
@@ -42,7 +44,7 @@ This document defines reusable UI components and their behaviors, independent of
 - Company name (primary text)
 - Position title (secondary text)
 - Status badge
-- Date applied
+- Date applied (displays '—' when null)
 - Company category (if set)
 - Skills match rating (if set)
 - Interview progress "X/Y stages" (if interviewing)
@@ -257,6 +259,7 @@ See [validation-rules.md](../domain/validation-rules.md).
 
 | Status | Color Category |
 |--------|----------------|
+| unsubmitted | Draft (gray) |
 | applied | Neutral (gray/blue) |
 | interviewing | Active (blue/purple) |
 | given offer | Warning (yellow/orange) |
@@ -387,6 +390,92 @@ See [validation-rules.md](../domain/validation-rules.md).
 - Click Previous → go to previous page (disabled on page 1)
 - Click Next → go to next page (disabled on last page)
 - Show subset of pages with ellipsis for large page counts
+
+---
+
+## Component: HistoryPanel
+
+**Purpose**: Sliding side panel showing the history of changes to an application.
+
+### Props/Inputs
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| applicationId | UUID | yes | Application to show history for |
+| isOpen | boolean | yes | Whether the panel is visible |
+| onClose | function | yes | Handler for closing the panel |
+| onRestore | function | yes | Handler for restoring to a version |
+
+### Display Elements
+
+- Panel title "Change History" with close button
+- Timeline list of history entries, newest first
+- Each entry shows:
+  - Human-readable description (e.g., "Status changed to interviewing")
+  - Relative timestamp (e.g., "2 hours ago")
+  - Expand/collapse toggle for field-level diffs
+- Expanded entry shows:
+  - List of changed fields
+  - Old value (struck-through, red/muted)
+  - New value (green/highlighted)
+  - "Restore to this point" button (except on most recent entry)
+
+### Interactions
+
+- Click entry → expand/collapse field diffs
+- Click "Restore to this point" → confirm dialog → restore application
+- Click close or click outside → panel closes
+- Escape key → panel closes
+
+### Variants
+
+| State | Visual Treatment |
+|-------|------------------|
+| Loading | Skeleton placeholder entries |
+| Empty | "No history available" message |
+| Entry expanded | Diffs visible below description |
+| Current version | Marked "(current)" with no restore button |
+
+---
+
+## Component: ImportModal
+
+**Purpose**: Dialog for uploading a CSV file and viewing import results.
+
+### Props/Inputs
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| isOpen | boolean | yes | Whether the modal is visible |
+| onClose | function | yes | Handler for closing |
+| onImportComplete | function | yes | Handler called after successful import |
+
+### Display Elements
+
+- Modal title "Import Applications from CSV"
+- Download template link
+- File input accepting .csv files only
+- Upload/import button
+- Results section (shown after upload):
+  - Imported count (success)
+  - Skipped count (duplicates)
+  - Error count with per-row details
+
+### Interactions
+
+- Select file → enable upload button
+- Click upload → show loading, process file, show results
+- Click "Download Template" → browser downloads template CSV
+- Click close → dismiss modal, refresh application list if imports occurred
+
+### States
+
+| State | Behavior |
+|-------|----------|
+| Initial | File picker shown, no results |
+| Uploading | Loading indicator, controls disabled |
+| Results | Counts shown, file picker reset for another import |
+| Error | Upload-level error message (e.g., not a CSV file) |
 
 ---
 

--- a/specs/core/ui/screens.md
+++ b/specs/core/ui/screens.md
@@ -26,7 +26,7 @@ Note: This is a single-page application with most interactions via modals. Alter
 ┌─────────────────────────────────────────────────────────────────┐
 │ HEADER                                                          │
 │ ┌─────────────────────────────────┐  ┌───────────────────────┐ │
-│ │ Job Application Tracker         │  │ [Theme Toggle] [+ Add]│ │
+│ │ Job Application Tracker         │  │ [Theme] [Import] [Export] [+ Add]│ │
 │ └─────────────────────────────────┘  └───────────────────────┘ │
 ├─────────────────────────────────────────────────────────────────┤
 │ FILTERS & SORT BAR                                              │
@@ -106,7 +106,7 @@ Note: This is a single-page application with most interactions via modals. Alter
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │ HEADER                                                          │
-│ ← Back to List                              [Edit] [Archive]   │
+│ ← Back to List                     [History] [Edit] [Archive]   │
 ├─────────────────────────────────────────────────────────────────┤
 │ APPLICATION HEADER                                              │
 │ ┌─────────────────────────────────────────────────────────────┐ │
@@ -149,6 +149,19 @@ Note: This is a single-page application with most interactions via modals. Alter
 │ SPECIAL REQUIREMENTS                                            │
 │ ┌─────────────────────────────────────────────────────────────┐ │
 │ │ Portfolio required. Code sample in Python or TypeScript.   │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────────┤
+│ HISTORY PANEL (slides from right when History clicked)           │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ Change History                                    [X Close] │ │
+│ │                                                             │ │
+│ │ ● Status changed to "interviewing"         2 hours ago     │ │
+│ │   ▸ Click to expand diffs                                  │ │
+│ │                                                             │ │
+│ │ ● Application created                          yesterday   │ │
+│ │   status: — → applied                                      │ │
+│ │   companyName: — → Acme Corp                               │ │
+│ │   [Restore to this point]                                  │ │
 │ └─────────────────────────────────────────────────────────────┘ │
 ├─────────────────────────────────────────────────────────────────┤
 │ FOOTER                                                          │
@@ -216,8 +229,8 @@ Note: This is a single-page application with most interactions via modals. Alter
 │ REQUIRED FIELDS                                                 │
 │ Company Name*     [________________________]                    │
 │ Position Title*   [________________________]                    │
-│ Date Applied      [____/____/____] (defaults to today)         │
-│ Status            [Applied ▼]                                   │
+│ Date Applied      [____/____/____] (empty by default)          │
+│ Status            [Unsubmitted ▼]                               │
 ├─────────────────────────────────────────────────────────────────┤
 │ COMPANY DETAILS                                                 │
 │ Company Website   [________________________]                    │
@@ -301,6 +314,38 @@ Note: This is a single-page application with most interactions via modals. Alter
 │ notes will be permanently removed.                              │
 ├─────────────────────────────────────────────────────────────────┤
 │                                         [Cancel]  [Delete]      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Modal: Import CSV
+
+**Purpose**: Upload a CSV file to bulk-create applications.
+
+### Layout
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Import Applications from CSV                             [X Close]│
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│ Upload a CSV file to create multiple applications at once.      │
+│ [Download Template] to see the expected format.                 │
+│                                                                 │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │  📂 Choose CSV file...                          [Browse]   │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│                                                                 │
+│ RESULTS (shown after upload)                                    │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ ✓ 8 imported  |  ⊘ 2 skipped (duplicates)  |  ✗ 1 error  │ │
+│ │                                                             │ │
+│ │ Errors:                                                     │ │
+│ │ • Row 5: Invalid status "pending"                           │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│                                                                 │
+│                                                      [Close]    │
 └─────────────────────────────────────────────────────────────────┘
 ```
 

--- a/specs/core/ui/user-flows.md
+++ b/specs/core/ui/user-flows.md
@@ -28,8 +28,8 @@ flowchart TD
 
 1. User is on the Application List screen
 2. User clicks "Add Application" button
-3. Modal opens with empty form
-4. User enters required fields (company name, position title)
+3. Modal opens with empty form (status defaults to Unsubmitted, date applied is empty)
+4. User enters required fields (company name, position title); date applied and status can be changed from defaults
 5. User optionally fills additional fields
 6. User clicks "Save"
 7. System validates input
@@ -317,6 +317,95 @@ flowchart TD
 4. User adds their first application
 5. Application appears in list
 6. User understands the basic workflow
+
+---
+
+## Flow 10: View and Restore Application History
+
+**Goal**: User reviews past changes to an application and optionally restores a previous version.
+
+```mermaid
+flowchart TD
+    A[View Application Detail] --> B[Click History Button]
+    B --> C[History Panel Slides Open]
+    C --> D[See Timeline of Changes]
+    D --> E[Click Entry to Expand]
+    E --> F[See Field-Level Diffs]
+    F --> G{Want to Restore?}
+    G -->|No| H[Close Panel]
+    G -->|Yes| I[Click Restore to This Point]
+    I --> J[Confirmation Dialog]
+    J -->|Confirm| K[Application Restored]
+    K --> L[New History Entry Created]
+    J -->|Cancel| D
+```
+
+### Steps
+
+1. User views an application detail page
+2. User clicks "History" button in the header
+3. Side panel slides open showing change timeline (newest first)
+4. User clicks an entry to expand field-level diffs
+5. User sees old values (struck-through) and new values
+6. User optionally clicks "Restore to this point"
+7. Confirmation dialog appears
+8. On confirm: application reverts to that snapshot's state
+9. New "Restored to version N" entry appears in history
+10. History panel updates to show the restore entry
+
+---
+
+## Flow 11: Import Applications from CSV
+
+**Goal**: User bulk-creates applications by uploading a CSV file.
+
+```mermaid
+flowchart TD
+    A[View Application List] --> B[Click Import]
+    B --> C[Import Modal Opens]
+    C --> D{Has Template?}
+    D -->|No| E[Download Template]
+    E --> F[Fill in CSV Data]
+    D -->|Yes| F
+    F --> G[Select CSV File]
+    G --> H[Click Upload]
+    H --> I[Processing...]
+    I --> J[Results Displayed]
+    J --> K[Close Modal]
+    K --> L[List Refreshes with New Apps]
+```
+
+### Steps
+
+1. User clicks "Import" button on the application list
+2. Import modal opens with file picker
+3. Optionally: user downloads template CSV for reference
+4. User selects a CSV file from their computer
+5. System uploads and processes the file row-by-row
+6. Modal displays results: N imported, N skipped (duplicates), N errors
+7. Errors show row number and description
+8. User closes modal
+9. Application list refreshes to include newly imported applications
+
+---
+
+## Flow 12: Export Applications to CSV
+
+**Goal**: User downloads all applications as a CSV file.
+
+```mermaid
+flowchart TD
+    A[View Application List] --> B[Click Export]
+    B --> C[Browser Downloads CSV]
+    C --> D[File: applications-YYYY-MM-DD.csv]
+```
+
+### Steps
+
+1. User clicks "Export" button on the application list
+2. Browser downloads a CSV file named `applications-YYYY-MM-DD.csv`
+3. CSV contains all applications (active and archived) with 16 columns
+4. Interview stages are excluded from the export (too complex for flat CSV)
 
 ---
 


### PR DESCRIPTION
## Summary

Brings `specs/core/` up to date with all implemented features. The core specs previously only covered the original 5 features (CRUD, interviews, offers, filtering, archive/delete) but several major features have been implemented across all stacks without being reflected.

### Changes

**Domain model updates** (4 files)
- `entities.md` — dateApplied now nullable, status defaults to "unsubmitted", added ApplicationSnapshot entity
- `enums.md` — added `unsubmitted` status, "Draft" category, default sort note (`updatedAt` desc)
- `validation-rules.md` — nullable dateApplied rules, unsubmitted cross-field constraint
- `state-transitions.md` — `unsubmitted` as initial state, 5 new transitions with dateApplied auto-populate/clear

**New core feature specs** (4 files created)
- `006-history.md` — P2: View timeline, field-level diffs, restore to version
- `007-csv-import-export.md` — P2: Import, export, template, duplicate detection
- `008-inline-editing.md` — P3: Edit in-place on detail page
- `009-resizable-textareas.md` — P3: Vertical resize with persisted height

**API contract** (`openapi.yaml`)
- `unsubmitted` enum value, nullable dateApplied, sortBy default fixed to `updatedAt`
- 5 new endpoints: history, restore, import, export, sample-csv
- 2 new schemas: HistoryEntry, ImportResult

**UI specs** (3 files)
- HistoryPanel + ImportModal components, Import/Export/History buttons in wireframes
- Updated form defaults (Unsubmitted, empty dateApplied)
- 3 new user flows (history, import, export)

**Feature spec statuses** (7 files)
- Specs 006–012 updated from Draft/In Progress → Complete

## Test plan
- [ ] Verify all markdown links in README.md resolve correctly
- [ ] Verify OpenAPI YAML is valid (no syntax errors)
- [ ] Confirm `unsubmitted` appears consistently across all specs that reference status

🤖 Generated with [Claude Code](https://claude.ai/code)