### PR TITLE
docs: prune CLAUDE.md of non-assistant-directed content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Repository Overview
 
 Monorepo with multiple frontend+backend implementation pairs sharing a single PostgreSQL database. Skills in `.claude/skills/`, commands in `.claude/commands/`.
@@ -107,12 +105,12 @@ Prefer individual CRUD operations (`addStage`, `updateStage`, `removeStage`) ove
 - **Worktree/subagent sessions**: Auto-commit before returning (worktree is ephemeral)
 - **After every push to a PR branch** *(required, no exceptions)*: Immediately update the PR body via `gh pr edit <number> --body` to reflect all commits now on the branch. Do not wait to be asked. Do not skip because the change "seems minor" — always re-read the current description and update it.
 - **Spec status**: When a feature has a spec file in `specs/`, update its `Status` to `Complete` before merging the PR
-- **Before merging**: Mention to the user — "Worth running `/learn` if anything non-obvious came up this session." One sentence, easy to dismiss for small PRs.
+- **Before merging**: Ask the user — "Worth running `/learn` if anything non-obvious came up this session." Wait for their response before proceeding with the merge.
 - **Wait for CI before merging**: Always check `gh pr checks <number>` and wait for all checks to pass before squash merging. Do not use `--admin` to bypass branch protection unless explicitly asked.
 - **Post-merge cleanup**: After squash merging a PR, immediately switch to main, pull, and delete the local branch (`git checkout main && git pull && git branch -d <branch>`). Never commit cleanup work (e.g. spec status updates) directly to local main — branch protection will reject the push, and the resulting squash PR will diverge from the local commit, causing a merge commit on the next pull instead of a fast-forward.
 - **Resolving PR review threads**: `gh` CLI has no resolve command. Use `gh api graphql` — fetch thread IDs via `pullRequest.reviewThreads`, resolve with `resolveReviewThread` mutation. Reply to each thread before resolving.
 - **CI toolchain parity**: When adding a new language/toolchain to the monorepo (e.g., Python/uv), update `.github/workflows/verify-pr.yaml` in the same PR to install the required tools
-- **Documentation**: When adding a new implementation update: `README.md` (TOC, implementations, running instructions, test commands), and as needed `CLAUDE.md`. When DB schema changes are involved, update `docs/DATABASE_ARCHITECTURE.md`, `scripts/generate-schema-docs.sh`, and run `npm run docs:schema`. If Typescript changes run `npm run docs:types` or new ts implementations add script. Do not wait to be asked — include docs in the implementation plan.
+- **Documentation**: When adding a new implementation, update: `README.md` (TOC, implementations, running instructions, test commands), and as needed `CLAUDE.md`. When DB schema changes are involved, update `docs/DATABASE_ARCHITECTURE.md`, `scripts/generate-schema-docs.sh`, and run `npm run docs:schema`. When adding a TypeScript implementation, add a `docs:types:<stack>` script. Do not wait to be asked — include docs in the implementation plan.
 
 ## Running E2E Tests
 


### PR DESCRIPTION
## Summary
- Remove opening meta-description sentence (the assistant already knows what CLAUDE.md is for)
- Clarify `/learn` pre-merge prompt: change \"Mention\" to \"Ask\" and add explicit \"wait for response before merging\"
- Tighten documentation bullet: remove redundant TS `docs:types` note (already covered by its own dedicated bullet), clarify that new TypeScript implementations should add a `docs:types:<stack>` script

## Test Plan
- [ ] Read through CLAUDE.md and confirm all remaining content is actionable assistant guidance

---
Generated with [Claude Code](https://claude.ai/code)