### PR TITLE
feat: improve E2E test quality across all stacks (spec 020)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -91,6 +91,13 @@
       "mode": "auto",
       "program": "${workspaceFolder}/go-api/cmd/server",
       "envFile": "${workspaceFolder}/go-api/.env"
-    }
+    },
+    {
+      "name": "Java Spring API (Attach)",
+      "type": "java",
+      "request": "attach",
+      "hostName": "localhost",
+      "port": 5005
+    },
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Prefer individual CRUD operations (`addStage`, `updateStage`, `removeStage`) ove
 - **React Router useBlocker**: Only works with `createBrowserRouter` + `RouterProvider`, not `<BrowserRouter>`
 - **SvelteKit SSR**: Add `export const ssr = false` in `src/routes/+layout.ts` for SPA mode with Playwright
 - **Svelte 5 bind:value**: Doesn't propagate with callback `onchange` — use local `$state` + `$effect`, call callback in `oninput`
-- **Shared E2E history tests**: `history.spec.ts` has a single `History Panel` block shared by Vue and Svelte; stacks without history use `rg --invert-match 'History Panel'`
+- **Shared E2E history tests**: `history.spec.ts` has a single `History Panel` block shared by Vue and Svelte; stacks without history use `--grep-invert 'History Panel'` (Playwright CLI flag)
 - **Avoid absolute positioning for sibling elements**: When multiple elements share the same corner (e.g., badge + action menu), use flexbox flow instead of `absolute` — prevents overlap
 - **Validation limit changes**: When updating max lengths in constants/schemas, rg (ripgrep) for hardcoded boundary values in tests (e.g., `repeat(1001)`) — tests may silently pass with stale limits
 - **Svelte 5 event delegation**: `stopPropagation()` doesn't prevent parent `<a>` navigation — avoid wrapping interactive cards in `<a>` tags; use `onclick` with `goto()` instead

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,13 +82,20 @@ Prefer individual CRUD operations (`addStage`, `updateStage`, `removeStage`) ove
 - **React Router useBlocker**: Only works with `createBrowserRouter` + `RouterProvider`, not `<BrowserRouter>`
 - **SvelteKit SSR**: Add `export const ssr = false` in `src/routes/+layout.ts` for SPA mode with Playwright
 - **Svelte 5 bind:value**: Doesn't propagate with callback `onchange` — use local `$state` + `$effect`, call callback in `oninput`
-- **Shared E2E history tests**: `history.spec.ts` has a single `History Panel` block shared by Vue and Svelte; stacks without history use `--grep-invert 'History Panel'`
+- **Shared E2E history tests**: `history.spec.ts` has a single `History Panel` block shared by Vue and Svelte; stacks without history use `rg --invert-match 'History Panel'`
 - **Avoid absolute positioning for sibling elements**: When multiple elements share the same corner (e.g., badge + action menu), use flexbox flow instead of `absolute` — prevents overlap
-- **Validation limit changes**: When updating max lengths in constants/schemas, grep for hardcoded boundary values in tests (e.g., `repeat(1001)`) — tests may silently pass with stale limits
+- **Validation limit changes**: When updating max lengths in constants/schemas, rg (ripgrep) for hardcoded boundary values in tests (e.g., `repeat(1001)`) — tests may silently pass with stale limits
 - **Svelte 5 event delegation**: `stopPropagation()` doesn't prevent parent `<a>` navigation — avoid wrapping interactive cards in `<a>` tags; use `onclick` with `goto()` instead
 - **Zod boolean coercion**: `z.coerce.boolean()` treats any non-empty string (including `"false"`) as `true` — use `z.preprocess((val) => val === 'true' || val === true, z.boolean())` for query params
 - **Playwright count assertions**: Use `/\b1(?!\d)/` not `/\b1\b/` for exact count checks — `\b` fails when the digit is immediately adjacent to a letter (e.g. Angular renders `"1Skipped"` without whitespace between count and label)
 - **Playwright `toHaveText` vs `toContainText`**: `toHaveText(regex)` requires a full match including surrounding whitespace from padding; use `toContainText(regex)` when the element has CSS padding that adds whitespace around the text content
+- **Null vs undefined in validation**: API fields that are "not set" often return `null`, not `undefined`. Strict `!== undefined` checks let `null` slip into range/format validators where JS coercion causes false failures (e.g. `null < 1` → `true`) — use `!= null` (loose equality) to treat both as absent.
+- **webkit + React 19 form submission**: Playwright's `requestSubmit()`, button `.click()`, and `press('Enter')` do not fire React's `onSubmit` in webkit for multi-input forms. Workaround: extract a `doSubmit()` function, add `type="button"` + `data-testid="<form>-save"` + `onClick={doSubmit}` to the submit button, and use `page.locator('[data-testid="<form>-save"]').click()` in tests.
+- **Submit button type changes**: When changing a button from `type="submit"` to `type="button"`, unit tests using `querySelector('button[type="submit"]')` will silently return `null`. Prefer `getByTestId()` or `getByRole('button', { name: /save/i })` instead.
+
+## Angular Patterns
+
+- **Confirm dialog `role="dialog"`**: Locators using `[role="dialog"] button:has-text(...)` require the inner dialog container div to have `role="dialog"` — Angular components don't add it automatically. Always include `role="dialog"` on the modal content div in `ConfirmDialogComponent`.
 
 ## Vue.js Patterns
 
@@ -114,6 +121,11 @@ Prefer individual CRUD operations (`addStage`, `updateStage`, `removeStage`) ove
 - **LinkedIn URLs exceed VARCHAR(500)**: URL columns for job posting/company URLs should use `TEXT` — LinkedIn tracking URLs commonly exceed 500 chars
 - **Jackson date serialization**: `LocalDate`/`LocalDateTime` serialize as arrays (e.g. `[2026,3,5]`) by default — add `.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)` to `ObjectMapper` config to get ISO strings (`"2026-03-05"`, `"2026-03-05T13:00:00Z"`)
 
+## Terminal Management
+
+- **Repeated test runs**: Run iterative/debugging test commands as foreground tasks in one shared terminal rather than spawning a new background terminal each iteration — background terminals accumulate and are never auto-cleaned.
+- **Kill background terminals promptly**: Call `kill_terminal` immediately after a background process is no longer needed; IDs are only available in the current session and cannot be recovered later.
+
 ## Subagent Usage
 
 - **Prefer blocking parallel**: Use normal parallel `Task` calls when no other work to do. Only `run_in_background: true` when continuing other work.
@@ -131,11 +143,11 @@ Prefer individual CRUD operations (`addStage`, `updateStage`, `removeStage`) ove
 - **Post-merge cleanup**: After squash merging a PR, immediately switch to main, pull, and delete the local branch (`git checkout main && git pull && git branch -d <branch>`). Never commit cleanup work (e.g. spec status updates) directly to local main — branch protection will reject the push, and the resulting squash PR will diverge from the local commit, causing a merge commit on the next pull instead of a fast-forward.
 - **Resolving PR review threads**: `gh` CLI has no resolve command. Use `gh api graphql` — fetch thread IDs via `pullRequest.reviewThreads`, resolve with `resolveReviewThread` mutation. Reply to each thread before resolving.
 - **CI toolchain parity**: When adding a new language/toolchain to the monorepo (e.g., Python/uv), update `.github/workflows/verify-pr.yaml` in the same PR to install the required tools
-- **Documentation**: When adding a new implementation, update: `README.md` (TOC, implementations, running instructions, test commands), and as needed `CLAUDE.md`. When DB schema changes are involved, update `docs/DATABASE_ARCHITECTURE.md`, `scripts/generate-schema-docs.sh`, and run `npm run docs:schema`. When adding a TypeScript implementation, add a `docs:types:<stack>` script. Do not wait to be asked — include docs in the implementation plan.
+- **Documentation**: When adding a new implementation, update: `README.md` (TOC, implementations, running instructions, test commands), and as needed `CLAUDE.md`. When DB schema changes are involved, update `docs/DATABASE_ARCHITECTURE.md`, `scripts/generate-schema-docs.sh`, and run `npm run docs:schema`. When adding a TypeScript implementation, add a `docs:types:<stack>` script. Also add a debug configuration to `.vscode/launch.json` for the new API backend (use the appropriate debug type: `node` for TS/Node APIs, `debugpy` for Python, `go` for Go). For Java/Spring, use `type: java, request: attach` on port 5005 and add a `dev:<stack>:debug` npm script that runs `./gradlew bootRun --debug-jvm` — do not use `request: launch` as it requires full Java extension project resolution which is fragile. Do not wait to be asked — include docs in the implementation plan.
 
 ## Running E2E Tests
 
-**Server lifecycle**: For fully managed runs (API auto-start/stop), use `bash scripts/run-e2e.sh [stack|all]` — `npm run test:e2e:all` also uses this. To run manually when servers are already up, use `npm run test:e2e:<stack>` directly and leave pre-existing servers running afterward.
+**Server lifecycle**: For fully managed runs (API auto-start/stop), use `bash scripts/run-e2e.sh [stack|all]` — `npm run test:e2e:all` also uses this. To run manually when servers are already up, use `npm run test:e2e:<stack>` directly and leave pre-existing servers running afterward. **`npm run test:e2e:<stack>` only starts the UI dev server** (via playwright `webServer`), not the API backend — if you've killed the backend manually, use `bash scripts/run-e2e.sh <stack>` to restart it before running tests.
 
 Run all: `npm run test:e2e:all`. Run one stack: `npm run test:e2e:<stack>` (e.g., `react-next-ui`, `vue-ui`).
 
@@ -143,4 +155,12 @@ Each requires its backend running separately. See [docs/TESTING_REFERENCE.md](do
 
 **E2E test data cleanup**: Tests that create data must clean up in `afterAll` using API calls (e.g., `page.request.delete('/api/applications/${id}')`) — not fragile UI interactions. Cleanup must run even if individual tests fail.
 
-**Shared E2E tests run against all implementations**: Files in `tests/e2e/` are not stack-specific — every test runs against all 7 stacks. A fix for a failure on one stack can silently break another. Selectors, timing assumptions, and interaction patterns must work across React (SSR and CSR), Vue, Svelte, Angular, and Next.js. When modifying a shared E2E test, reason through how each stack will behave — e.g., React SSR apps require `waitForLoadState('networkidle')` before interacting with controlled inputs, while SPA frameworks handle `selectOption()` natively after `domcontentloaded`. After any change to a shared E2E file, run `npm run test:e2e:all` (or `bash scripts/run-e2e.sh`) to confirm nothing regressed across stacks.
+**Shared E2E tests run against all implementations**: Files in `tests/e2e/` are not stack-specific — every test runs against all 8 stacks. A fix for a failure on one stack can silently break another. Selectors, timing assumptions, and interaction patterns must work across React (SSR and CSR), Vue, Svelte, Angular, and Next.js. When modifying a shared E2E test, reason through how each stack will behave — e.g., React SSR apps require `waitForLoadState('networkidle')` before interacting with controlled inputs, while SPA frameworks handle `selectOption()` natively after `domcontentloaded`. After any change to a shared E2E file, run `npm run test:e2e:all` (or `bash scripts/run-e2e.sh`) to confirm nothing regressed across stacks.
+
+**E2E `beforeAll` PATCH must include all required fields**: Go and Spring backends reject partial PATCHes (e.g. `{ status: 'applied' }` alone) because `companyName` and `positionTitle` are required. Always send the full required body in `beforeAll` PATCHes: `{ companyName, positionTitle, status }`. Note: some backends also strip unknown POST fields, so status cannot always be set at create time — a two-step POST + full PATCH is the safe pattern for all stacks.
+
+**`test.describe.serial` for `beforeAll`-dependent tests**: With `fullyParallel: true`, `test.describe` (non-serial) runs each worker with an independent module load — module-scope variables like `const company = uniqueCompanyName(...)` produce different values per worker, so `beforeAll`-created data is invisible to `beforeEach` in other workers. Use `test.describe.serial` for any describe block whose tests share `beforeAll` setup data.
+
+## Searching files
+
+-  **Use 'rg' (ripgrep)** instead of 'grep' or 'find' for better performance and features

--- a/angular-spring-ui/src/app/features/applications/csv/csv-import.component.ts
+++ b/angular-spring-ui/src/app/features/applications/csv/csv-import.component.ts
@@ -42,14 +42,18 @@ import { ImportResult } from '../../../core/models/application.model';
         </button>
       </div>
 
-      <div [hidden]="!result()" class="p-3 bg-green-50 border border-green-200 rounded text-sm dark:bg-green-900/20 dark:border-green-800 space-y-1">
-          <p class="font-medium text-green-800 dark:text-green-400">Imported: {{ result()?.imported ?? 0 }}</p>
-          <p class="font-medium text-green-800 dark:text-green-400">Skipped: {{ result()?.skipped ?? 0 }}</p>
+      @if (result()) {
+        <div class="p-3 bg-green-50 border border-green-200 rounded text-sm dark:bg-green-900/20 dark:border-green-800 space-y-1">
+          <p class="font-medium text-green-800 dark:text-green-400">Imported: {{ result()!.imported }}</p>
+          <p class="font-medium text-green-800 dark:text-green-400">Skipped: {{ result()!.skipped }}</p>
           <div data-testid="import-result-errors" class="font-medium text-green-800 dark:text-green-400">
-            Errors: {{ result()?.errors?.length ?? 0 }}
-            <pre [hidden]="!errorLines().length" class="mt-1 whitespace-pre-wrap text-red-700 dark:text-red-400 font-sans text-sm">{{ errorLines().join('\n') }}</pre>
+            Errors: {{ result()!.errors.length }}
+            @if (errorLines().length) {
+              <pre class="mt-1 whitespace-pre-wrap text-red-700 dark:text-red-400 font-sans text-sm">{{ errorLines().join('\n') }}</pre>
+            }
           </div>
         </div>
+      }
 
       <p [hidden]="!error()" class="text-sm text-red-600 dark:text-red-400">{{ error() }}</p>
     </div>

--- a/angular-spring-ui/src/app/features/applications/history/history-panel.component.ts
+++ b/angular-spring-ui/src/app/features/applications/history/history-panel.component.ts
@@ -26,6 +26,7 @@ import { RelativeDatePipe } from '../../../shared/pipes/relative-date.pipe';
 
     <!-- Slide-in panel -->
     <div
+      data-testid="history-panel"
       class="fixed inset-y-0 right-0 w-96 bg-white shadow-xl z-50 flex flex-col dark:bg-gray-800"
     >
       <div class="flex items-center justify-between px-4 py-3 border-b dark:border-gray-700">
@@ -51,7 +52,7 @@ import { RelativeDatePipe } from '../../../shared/pipes/relative-date.pipe';
         } @else {
           <div class="space-y-1">
             @for (entry of history(); track entry.id; let i = $index) {
-              <div class="border border-gray-200 rounded-lg overflow-hidden dark:border-gray-700">
+              <div data-testid="history-entry" class="border border-gray-200 rounded-lg overflow-hidden dark:border-gray-700">
                 <button
                   type="button"
                   (click)="toggleEntry(entry.id)"

--- a/angular-spring-ui/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/angular-spring-ui/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -5,7 +5,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   standalone: true,
   template: `
     <div class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
-      <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl dark:bg-gray-800">
+      <div role="dialog" class="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl dark:bg-gray-800">
         <h3 class="text-lg font-semibold text-gray-900 mb-2 dark:text-white">{{ title }}</h3>
         <p class="text-gray-600 mb-4 dark:text-gray-300">{{ message }}</p>
         <div class="flex justify-end gap-3">

--- a/angular-ui/src/app/core/services/application.service.ts
+++ b/angular-ui/src/app/core/services/application.service.ts
@@ -134,8 +134,8 @@ export class ApplicationService {
 
   addStage(id: string, stage: Partial<InterviewStage>): Observable<Application> {
     const payload = {
-      stageName: stage.name,
-      stageOrder: stage.order,
+      name: stage.name,
+      order: stage.order,
       isCompleted: stage.isCompleted ?? false,
     };
     return this.http
@@ -149,8 +149,8 @@ export class ApplicationService {
     stage: Partial<InterviewStage>
   ): Observable<Application> {
     const payload = {
-      stageName: stage.name,
-      stageOrder: stage.order,
+      name: stage.name,
+      order: stage.order,
       isCompleted: stage.isCompleted ?? false,
     };
     return this.http

--- a/angular-ui/src/app/features/history-panel/history-panel.component.ts
+++ b/angular-ui/src/app/features/history-panel/history-panel.component.ts
@@ -26,6 +26,7 @@ import { RelativeDatePipe } from '../../shared/pipes/relative-date.pipe';
 
     <!-- Slide-in panel -->
     <div
+      data-testid="history-panel"
       class="fixed inset-y-0 right-0 w-96 bg-white shadow-xl z-50 flex flex-col dark:bg-gray-800"
     >
       <div class="flex items-center justify-between px-4 py-3 border-b dark:border-gray-700">
@@ -51,7 +52,7 @@ import { RelativeDatePipe } from '../../shared/pipes/relative-date.pipe';
         } @else {
           <div class="space-y-1">
             @for (entry of history(); track entry.id; let i = $index) {
-              <div class="border border-gray-200 rounded-lg overflow-hidden dark:border-gray-700">
+              <div data-testid="history-entry" class="border border-gray-200 rounded-lg overflow-hidden dark:border-gray-700">
                 <button
                   type="button"
                   (click)="toggleEntry(entry.id)"

--- a/angular-ui/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/angular-ui/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -5,7 +5,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   standalone: true,
   template: `
     <div class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
-      <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl dark:bg-gray-800">
+      <div role="dialog" class="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl dark:bg-gray-800">
         <h3 class="text-lg font-semibold text-gray-900 mb-2 dark:text-white">{{ title }}</h3>
         <p class="text-gray-600 mb-4 dark:text-gray-300">{{ message }}</p>
         <div class="flex justify-end gap-3">

--- a/go-api/internal/handler/applications.go
+++ b/go-api/internal/handler/applications.go
@@ -109,7 +109,7 @@ func createApplication(pool *pgxpool.Pool) gin.HandlerFunc {
 
 		app, err := service.CreateApplication(c.Request.Context(), pool, input)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 		c.JSON(http.StatusCreated, app)

--- a/go-api/internal/handler/applications.go
+++ b/go-api/internal/handler/applications.go
@@ -109,7 +109,11 @@ func createApplication(pool *pgxpool.Pool) gin.HandlerFunc {
 
 		app, err := service.CreateApplication(c.Request.Context(), pool, input)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			status := http.StatusInternalServerError
+			if _, ok := err.(*service.ErrValidation); ok {
+				status = http.StatusBadRequest
+			}
+			c.JSON(status, gin.H{"error": err.Error()})
 			return
 		}
 		c.JSON(http.StatusCreated, app)

--- a/go-api/internal/service/applications.go
+++ b/go-api/internal/service/applications.go
@@ -12,6 +12,11 @@ import (
 	"github.com/user/application-tracker/go-api/internal/db"
 )
 
+// ErrValidation is returned when the caller provides invalid input (maps to HTTP 400).
+type ErrValidation struct{ Message string }
+
+func (e *ErrValidation) Error() string { return e.Message }
+
 // ApplicationInput holds the fields for creating or updating an application.
 type ApplicationInput struct {
 	CompanyName         string  `json:"companyName"`
@@ -296,7 +301,7 @@ func GetApplication(ctx context.Context, pool *pgxpool.Pool, id string) (*Applic
 // CreateApplication creates a new application.
 func CreateApplication(ctx context.Context, pool *pgxpool.Pool, input ApplicationInput) (*ApplicationResponse, error) {
 	if input.CompanyName == "" || input.PositionTitle == "" {
-		return nil, fmt.Errorf("companyName and positionTitle are required")
+		return nil, &ErrValidation{Message: "companyName and positionTitle are required"}
 	}
 	if input.Status == "" {
 		input.Status = "unsubmitted"

--- a/go-api/internal/service/applications.go
+++ b/go-api/internal/service/applications.go
@@ -14,8 +14,8 @@ import (
 
 // ApplicationInput holds the fields for creating or updating an application.
 type ApplicationInput struct {
-	CompanyName         string  `json:"companyName" binding:"required"`
-	PositionTitle       string  `json:"positionTitle" binding:"required"`
+	CompanyName         string  `json:"companyName"`
+	PositionTitle       string  `json:"positionTitle"`
 	Status              string  `json:"status"`
 	DateApplied         *string `json:"dateApplied"`
 	CompanyURL          *string `json:"companyUrl"`
@@ -295,6 +295,9 @@ func GetApplication(ctx context.Context, pool *pgxpool.Pool, id string) (*Applic
 
 // CreateApplication creates a new application.
 func CreateApplication(ctx context.Context, pool *pgxpool.Pool, input ApplicationInput) (*ApplicationResponse, error) {
+	if input.CompanyName == "" || input.PositionTitle == "" {
+		return nil, fmt.Errorf("companyName and positionTitle are required")
+	}
 	if input.Status == "" {
 		input.Status = "unsubmitted"
 	}
@@ -348,6 +351,12 @@ func UpdateApplication(ctx context.Context, pool *pgxpool.Pool, id string, input
 		return nil, nil
 	}
 
+	if input.CompanyName == "" {
+		input.CompanyName = existing.CompanyName
+	}
+	if input.PositionTitle == "" {
+		input.PositionTitle = existing.PositionTitle
+	}
 	if input.Status == "" {
 		input.Status = existing.Status
 	}

--- a/go-api/internal/service/stages.go
+++ b/go-api/internal/service/stages.go
@@ -15,8 +15,8 @@ var ErrStageNotFound = errors.New("stage not found")
 
 // StageInput holds the fields for creating or updating an interview stage.
 type StageInput struct {
-	StageName         string  `json:"stageName" binding:"required"`
-	StageOrder        int32   `json:"stageOrder"`
+	StageName         string  `json:"name" binding:"required"`
+	StageOrder        int32   `json:"order"`
 	IsCompleted       bool    `json:"isCompleted"`
 	PerformanceRating *string `json:"performanceRating"`
 	Notes             *string `json:"notes"`

--- a/go-api/tests/stages_test.go
+++ b/go-api/tests/stages_test.go
@@ -38,8 +38,8 @@ func TestAddStage(t *testing.T) {
 	defer deleteApp(t, srv.URL, app.ID)
 
 	stageBody, _ := json.Marshal(map[string]interface{}{
-		"stageName":  "Phone Screen",
-		"stageOrder": 1,
+		"name":  "Phone Screen",
+		"order": 1,
 	})
 	resp, err := http.Post(
 		fmt.Sprintf("%s/applications/%s/interview-stages", srv.URL, app.ID),
@@ -69,8 +69,8 @@ func TestUpdateStage(t *testing.T) {
 
 	// Add stage
 	stageBody, _ := json.Marshal(map[string]interface{}{
-		"stageName":  "Initial Screen",
-		"stageOrder": 1,
+		"name":  "Initial Screen",
+		"order": 1,
 	})
 	addResp, err := http.Post(
 		fmt.Sprintf("%s/applications/%s/interview-stages", srv.URL, app.ID),
@@ -84,8 +84,8 @@ func TestUpdateStage(t *testing.T) {
 
 	// Update stage
 	updateBody, _ := json.Marshal(map[string]interface{}{
-		"stageName":  "Technical Interview",
-		"stageOrder": 1,
+		"name":  "Technical Interview",
+		"order": 1,
 	})
 	req, _ := http.NewRequest(http.MethodPatch,
 		fmt.Sprintf("%s/applications/%s/interview-stages/%s", srv.URL, app.ID, stageID),
@@ -117,8 +117,8 @@ func TestRemoveStage(t *testing.T) {
 
 	// Add stage
 	stageBody, _ := json.Marshal(map[string]interface{}{
-		"stageName":  "Stage to Remove",
-		"stageOrder": 1,
+		"name":  "Stage to Remove",
+		"order": 1,
 	})
 	addResp, err := http.Post(
 		fmt.Sprintf("%s/applications/%s/interview-stages", srv.URL, app.ID),

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dev:go-api": "cd go-api && go run ./cmd/server",
     "dev:angular-ui": "cd angular-ui && npm start",
     "dev:spring-api": "cd spring-api && ./gradlew bootRun",
+    "dev:spring-api:debug": "cd spring-api && ./gradlew bootRun --debug-jvm",
     "dev:angular-spring-ui": "cd angular-spring-ui && npm run dev",
     "build:express-api": "cd api && npm run build",
     "build:react-next-ui": "cd ui && npm run build",

--- a/react-ui/src/components/applications/HistoryPanel.tsx
+++ b/react-ui/src/components/applications/HistoryPanel.tsx
@@ -88,7 +88,7 @@ export function HistoryPanel({
   }
 
   return (
-    <div className="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
+    <div data-testid="history-panel" className="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
@@ -133,7 +133,7 @@ export function HistoryPanel({
         ) : (
           <div className="space-y-1">
             {entries.map((entry, i) => (
-              <div key={entry.id}>
+              <div key={entry.id} data-testid="history-entry">
                 <button
                   onClick={() => toggleExpand(entry.id)}
                   className={`w-full text-left p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 ${

--- a/specs/020-e2e-test-quality/plan.md
+++ b/specs/020-e2e-test-quality/plan.md
@@ -1,0 +1,150 @@
+# Implementation Plan: E2E Test Quality Improvements
+
+## Approach
+
+Work in four sequential phases. Each phase is independently verifiable. No application logic changes — only test infrastructure, test files, and minimal UI attribute additions (`data-testid`).
+
+---
+
+## Phase 1 — Shared helpers + collision-safe IDs (Foundation)
+
+Before touching individual test files, establish the shared foundation so all subsequent changes can use it.
+
+**1.1** Create `tests/e2e/helpers.ts`:
+- `deleteApplicationViaApi(page, id)` — wraps `page.request.delete('/api/applications/${id}')`
+- `uniqueCompanyName(prefix)` — returns `${prefix} ${crypto.randomUUID().slice(0, 8)}`
+
+**1.2** In `csv-import-export.spec.ts`, replace `Date.now()`-based unique URL with `crypto.randomUUID()`. No other changes to this file.
+
+**Verification**: TypeScript compiles cleanly; no test regressions.
+
+---
+
+## Phase 2 — Fix flaky patterns in existing test files
+
+Apply all flaky-test fixes. Each fix is a targeted edit, not a rewrite.
+
+### 2.1 `application-crud.spec.ts`
+
+**F1 — API cleanup**: The `afterAll` in the "Application CRUD - Inline Edit" describe block navigates to each app URL and clicks Delete buttons. Replace with:
+```typescript
+test.afterAll(async ({ browser }) => {
+  if (createdIds.length === 0) return;
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  for (const id of createdIds) {
+    await deleteApplicationViaApi(page, id);
+  }
+  await context.close();
+});
+```
+This requires capturing the application `id` alongside (or instead of) the URL when each application is created. Update the `createdUrls` variable to `createdIds` (string array), or keep both as `createdApps: { id: string; url: string }[]`.
+
+**F2 — Dialog selector**: All occurrences of:
+```typescript
+await page.locator('button:has-text("Delete")').last().click();
+```
+replace with:
+```typescript
+await page.locator('[role="dialog"] button:has-text("Delete")').click();
+```
+Locate every occurrence with `grep -n 'last()' tests/e2e/application-crud.spec.ts` before editing.
+
+**F3 — NetworkIdle swallow**: Remove `.catch(() => null)` from the `waitForLoadState('networkidle')` call. Replace with a specific API response wait:
+```typescript
+await page.waitForResponse(
+  resp => resp.url().includes('/api/applications') && resp.status() === 200,
+  { timeout: 15000 }
+);
+```
+
+**F5 — Unique IDs**: Replace `Date.now()` with `uniqueCompanyName()` from helpers where used for collision-safe naming.
+
+### 2.2 `history.spec.ts`
+
+**F1 — API cleanup**: Capture the application `id` from the creation response in `beforeAll`. Replace the `afterAll` UI-click pattern with `deleteApplicationViaApi(page, applicationId)`.
+
+**F2 — Dialog selector**: Same replacement as 2.1 — scope confirm-delete button to `[role="dialog"]`.
+
+**F4 — CSS locators**: Replace Tailwind-coupled locators once S2 is done (Phase 3). Mark with a `TODO(020-F4)` comment in this phase as a placeholder if Phase 3 isn't complete yet.
+
+---
+
+## Phase 3 — Add data-testid to history UI components (S2)
+
+Add `data-testid="history-panel"` to the panel root element and `data-testid="history-entry"` to the repeating entry element in all four history-enabled UIs. These are additive HTML attribute changes — no logic changes.
+
+For each UI, locate the history panel component:
+- `ui/` — grep for `HistoryPanel` in `ui/src/`
+- `react-ui/` — grep for `HistoryPanel` in `react-ui/src/`
+- `vue-ui/` — grep for `HistoryPanel` in `vue-ui/src/`
+- `svelte-ui/` — grep for `HistoryPanel` in `svelte-ui/src/`
+
+After all four are updated, update `history.spec.ts` to use the new `data-testid` selectors (resolving the `TODO(020-F4)` from Phase 2).
+
+**Verification**: `npm run build:react-next-ui && npm run build:react-ui && npm run build:vue && npm run build:svelte` — no compilation errors.
+
+---
+
+## Phase 4 — New test coverage
+
+### 4.1 Filter coverage — `filter.spec.ts`
+
+Create `tests/e2e/filter.spec.ts` with a single describe block:
+
+```
+describe('Application list filtering')
+  beforeAll: create 2 applications via API
+    - app A: status "applied"
+    - app B: status "interviewing"
+
+  test: filter by "applied" — only app A visible, app B absent
+  test: filter by "interviewing" — only app B visible, app A absent
+  test: clear filter — both apps visible
+
+  afterAll: delete both via API
+```
+
+The filter mechanism varies by stack. Inspect how each stack exposes filter controls (status dropdown in list header, sidebar filter, etc.) using the selector contract in `docs/TESTING_REFERENCE.md`. Use a stable selector pattern (role or label, not CSS class).
+
+### 4.2 Stage edit and delete — extend `application-crud.spec.ts`
+
+Add a `describe('Interview stage edit and delete')` block (serial, following the existing stage-creation test):
+
+```
+beforeAll: create application with one stage via UI form
+
+  test: edit stage — update stage name, save, reload, verify updated name persists
+  test: delete stage — click remove button, confirm, verify stage gone from list
+
+afterAll: delete application via API
+```
+
+---
+
+## Verification Steps
+
+After all phases are complete, run the full validation chain:
+
+1. **Build** — `npm run build:all` — no compilation errors
+2. **Lint** — `npm run lint:all` — no lint regressions
+3. **Unit tests** — `npm run test:all` — all existing tests pass
+4. **E2E — all stacks** — `bash scripts/run-e2e.sh all` — all stacks green (or use `npm run test:e2e:all`)
+
+Per-stack spot-check when servers are already running:
+```bash
+TEST_UI_PORT=3000 npm run test:e2e:react-next-ui
+TEST_UI_PORT=3010 npm run test:e2e:react-ui
+TEST_UI_PORT=3020 npm run test:e2e:vue-ui
+TEST_UI_PORT=3030 npm run test:e2e:svelte-ui
+TEST_UI_PORT=3040 npm run test:e2e:tanstack-start-ui
+TEST_UI_PORT=3050 npm run test:e2e:tanstack-ui
+TEST_UI_PORT=3060 npm run test:e2e:angular-ui
+TEST_UI_PORT=3070 npm run test:e2e:angular-spring-ui
+```
+
+---
+
+## Execution Approach
+
+Single session, sequential by phase. Each phase is small and verifiable independently. No parallel agents needed — all changes are in the test directory and UI component attribute additions. Total estimated test files touched: 4 + 4 UI components + 1 new file.

--- a/specs/020-e2e-test-quality/spec.md
+++ b/specs/020-e2e-test-quality/spec.md
@@ -1,0 +1,132 @@
+# Feature Specification: E2E Test Quality Improvements
+
+**Feature Branch**: `020-e2e-test-quality`
+**Created**: 2026-03-05
+**Status**: In Progress
+
+## Problem Statement
+
+A review of `tests/e2e/` identified recurring flaky-test risks, structural inconsistencies, and meaningful coverage gaps. The suite runs against 8 stacks; a single fragile selector or brittle cleanup can cause spurious failures across all of them. Fixing these issues before they manifest as flakiness in CI is cheaper than diagnosing them under time pressure.
+
+## Scope
+
+### Flaky-Test Fixes (test-file changes only)
+
+| ID | Issue | Location | Risk |
+|----|-------|----------|------|
+| F1 | UI-based cleanup in `afterAll` | `application-crud.spec.ts`, `history.spec.ts` | High |
+| F2 | `.last()` selector to dismiss confirm-delete dialog | `application-crud.spec.ts` (multiple), `history.spec.ts` | High |
+| F3 | `waitForLoadState('networkidle')` swallowed with `.catch(() => null)` | `application-crud.spec.ts` | High |
+| F4 | Tailwind CSS class selectors in history locators | `history.spec.ts` | Medium |
+| F5 | Timestamp-only unique IDs risk parallel collision | `application-crud.spec.ts`, `csv-import-export.spec.ts` | Medium |
+
+### Structural Improvements
+
+| ID | Change | Benefit |
+|----|--------|---------|
+| S1 | Shared `tests/e2e/helpers.ts` with `deleteApplicationViaApi` | Consistent teardown across all files |
+| S2 | `data-testid` on history panel and entry elements in each history-enabled UI | Decouples selector from Tailwind implementation |
+
+### Coverage Additions
+
+| ID | Feature | Gap |
+|----|---------|-----|
+| C1 | List filtering by status | Zero filter tests today |
+| C2 | Interview stage edit and delete | Only stage creation is tested |
+
+### Out of Scope
+
+- Cross-browser testing (Chromium, Firefox) — separate effort
+- Accessibility / keyboard navigation — separate effort
+- API error scenario tests (500, 404, timeout) — separate effort
+- Batch operations, search — not yet implemented in all stacks
+
+## Affected Files
+
+### Test files (all changes)
+- `tests/e2e/helpers.ts` — new shared helper module
+- `tests/e2e/application-crud.spec.ts` — F1, F2, F3, F5, C1, C2
+- `tests/e2e/history.spec.ts` — F1, F2, F4
+- `tests/e2e/csv-import-export.spec.ts` — F5 (parallel collision fix)
+
+### UI components (data-testid additions — S2)
+Each history-enabled UI needs `data-testid="history-panel"` on the panel root and `data-testid="history-entry"` on per-entry elements:
+
+| UI | History component location |
+|----|---------------------------|
+| `ui/` (Next.js + Express) | `ui/src/components/HistoryPanel.tsx` (or equivalent) |
+| `react-ui/` (React + Koa) | `react-ui/src/components/HistoryPanel.tsx` |
+| `vue-ui/` (Vue + Nuxt) | `vue-ui/src/components/HistoryPanel.vue` |
+| `svelte-ui/` (Svelte + Hono) | `svelte-ui/src/lib/components/HistoryPanel.svelte` |
+
+## Detailed Requirements
+
+### F1 — API-based cleanup
+`afterAll` blocks in `application-crud.spec.ts` and `history.spec.ts` must delete test data via `page.request.delete('/api/applications/:id')` rather than navigating to the application and clicking through the UI. The ID(s) must be captured during creation and stored in a suite-scoped variable.
+
+### F2 — Dialog-scoped delete selector
+The confirm-delete button click must be scoped to the dialog element:
+```typescript
+// Before (fragile — depends on exactly two "Delete" buttons on the page)
+await page.locator('button:has-text("Delete")').last().click();
+
+// After (explicit — scoped to dialog)
+await page.locator('[role="dialog"] button:has-text("Delete")').click();
+```
+
+### F3 — Remove swallowed networkidle
+Replace:
+```typescript
+await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => null);
+```
+With a specific API response wait scoped to the relevant request:
+```typescript
+await page.waitForResponse(resp => resp.url().includes('/api/applications') && resp.status() === 200);
+```
+
+### F4 — Semantic history locators
+Replace:
+```typescript
+page.locator('.fixed.inset-y-0.right-0')   // Tailwind panel
+page.locator('.space-y-1 > div')            // Entries container
+```
+With:
+```typescript
+page.locator('[data-testid="history-panel"]')
+page.locator('[data-testid="history-entry"]')
+```
+This requires S2 (adding `data-testid` attributes to each history component).
+
+### F5 — Collision-safe unique IDs
+Replace `Date.now()` with `crypto.randomUUID()` (or `test.info().workerIndex + '-' + Date.now()`) for test data unique identifiers.
+
+### S1 — Shared helpers
+`tests/e2e/helpers.ts` exports:
+```typescript
+export async function deleteApplicationViaApi(page: Page, id: string): Promise<void>
+export function uniqueCompanyName(prefix: string): string  // UUID-based
+```
+
+### C1 — Filter coverage
+New `tests/e2e/filter.spec.ts` (or added block in `application-crud.spec.ts`) covering:
+- Create 2 applications with different statuses
+- Filter to one status — only matching application visible
+- Clear filter — both visible again
+- Cleanup via API after suite
+
+### C2 — Stage edit and delete
+Extend the existing "Create application with interview stages" test or add a sibling describe block:
+- Create application with a stage
+- Edit the stage name/notes and verify the update persists
+- Delete the stage and verify it disappears from the list
+
+## Success Criteria
+
+1. All existing E2E tests pass with zero test-code changes beyond this spec — no regressions introduced
+2. `afterAll` blocks in `application-crud.spec.ts` and `history.spec.ts` use API deletion, not UI navigation
+3. No `.last()` selector used for dialog confirmation
+4. No `.catch(() => null)` on `waitForLoadState` calls
+5. `history.spec.ts` locators use `data-testid` attributes, not Tailwind class names
+6. New filter test passes across all stacks that support filtering
+7. New stage edit/delete test passes across all stacks
+8. `npm run test:e2e:all` (via `bash scripts/run-e2e.sh all`) passes green

--- a/specs/020-e2e-test-quality/spec.md
+++ b/specs/020-e2e-test-quality/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `020-e2e-test-quality`
 **Created**: 2026-03-05
-**Status**: In Progress
+**Status**: Complete
 
 ## Problem Statement
 
@@ -58,6 +58,12 @@ Each history-enabled UI needs `data-testid="history-panel"` on the panel root an
 | `react-ui/` (React + Koa) | `react-ui/src/components/HistoryPanel.tsx` |
 | `vue-ui/` (Vue + Nuxt) | `vue-ui/src/components/HistoryPanel.vue` |
 | `svelte-ui/` (Svelte + Hono) | `svelte-ui/src/lib/components/HistoryPanel.svelte` |
+| `tanstack-ui/` (TanStack + NestJS) | `tanstack-ui/src/components/applications/HistoryPanel.tsx` |
+| `tanstack-start-ui/` (TanStack Start + FastAPI) | `tanstack-start-ui/src/components/applications/HistoryPanel.tsx` |
+| `angular-ui/` (Angular + Go) | `angular-ui/src/app/features/history-panel/history-panel.component.ts` |
+| `angular-spring-ui/` (Angular + Spring) | `angular-spring-ui/src/app/features/applications/history/history-panel.component.ts` |
+
+> **Note**: The original spec scoped S2 to 4 UIs. During implementation, the remaining 4 stacks were found to also lack testids and were updated to ensure full cross-stack compatibility.
 
 ## Detailed Requirements
 
@@ -119,6 +125,19 @@ Extend the existing "Create application with interview stages" test or add a sib
 - Create application with a stage
 - Edit the stage name/notes and verify the update persists
 - Delete the stage and verify it disappears from the list
+
+## Discovered Fixes (Beyond Original Scope)
+
+The following bugs were uncovered during E2E test implementation and fixed as part of this feature:
+
+| Issue | Fix |
+|-------|-----|
+| Go API `binding:"required"` on `companyName`/`positionTitle` rejected partial PATCH `{ status }` with 400 | Removed required constraint from `ApplicationInput`; validation moved to service layer for create only |
+| Go `StageInput` JSON keys used `stageName`/`stageOrder` instead of `name`/`order` (inconsistent with OpenAPI spec and all other backends) | Fixed JSON tags in `StageInput`; updated Go tests and Angular service |
+| Angular confirm dialogs lacked `role="dialog"` — `[role="dialog"]` Playwright locator found no match | Added `role="dialog"` to both `angular-ui` and `angular-spring-ui` confirm dialog components |
+| svelte-ui `ApplicationCard` overflowed narrow viewports (iPhone SE 375px) in webkit due to CSS Grid `min-width: auto` | Added `min-w-0` to `ApplicationCard` root div |
+| `tanstack-start-ui` SSR singleton `queryClient` had `staleTime: 60s` — newly created test records hidden by cache | Set `staleTime: 0` |
+| `.vscode/launch.json` had broken `Spring API (Launch)` entry with wrong `mainClass` and `projectName` | Removed entry; retain `Java Spring API (Attach)` on port 5005; added `dev:spring-api:debug` npm script |
 
 ## Success Criteria
 

--- a/specs/020-e2e-test-quality/tasks.md
+++ b/specs/020-e2e-test-quality/tasks.md
@@ -49,6 +49,10 @@
 | 18 | `svelte-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ✅ |
 | 19 | `svelte-ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ✅ |
 | 20 | `tests/e2e/history.spec.ts` | Replace Tailwind CSS locators with `[data-testid="history-panel"]` and `[data-testid="history-entry"]` | F4 | ✅ |
+| 20a | `tanstack-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` and `data-testid="history-entry"` (discovered missing during implementation) | S2 | ✅ |
+| 20b | `tanstack-start-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` and `data-testid="history-entry"` (discovered missing during implementation) | S2 | ✅ |
+| 20c | `angular-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` and `data-testid="history-entry"` (discovered missing during implementation) | S2 | ✅ |
+| 20d | `angular-spring-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` and `data-testid="history-entry"` (discovered missing during implementation) | S2 | ✅ |
 
 ---
 
@@ -65,75 +69,7 @@
 
 | # | Command | Purpose | Status |
 |---|---------|---------|--------|
-| 23 | `npm run build:all` | No compilation errors from data-testid changes or new test files | ⬜ |
-| 24 | `npm run lint:all` | No lint regressions | ⬜ |
-| 25 | `npm run test:all` | Unit tests unaffected | ⬜ |
-| 26 | `bash scripts/run-e2e.sh all` | Full cross-stack E2E suite passes green | ⬜ |
-
----
-
-## Phase 1 — Shared helpers + collision-safe IDs
-
-| # | File | Change | Status |
-|---|------|--------|--------|
-| 1 | `tests/e2e/helpers.ts` *(new)* | Create with `deleteApplicationViaApi(page, id)` and `uniqueCompanyName(prefix)` helpers | ⬜ |
-| 2 | `tests/e2e/csv-import-export.spec.ts` | Replace `Date.now()` unique URL with `crypto.randomUUID()` (F5) | ⬜ |
-
----
-
-## Phase 2 — Fix flaky patterns in existing test files
-
-### application-crud.spec.ts
-
-| # | Change | Spec ID | Status |
-|---|--------|---------|--------|
-| 3 | Capture `id` (not just URL) when creating test apps; store as `createdApps: { id: string; url: string }[]` | F1 | ⬜ |
-| 4 | Replace `afterAll` UI-click cleanup with `deleteApplicationViaApi` loop over captured IDs | F1 | ⬜ |
-| 5 | Replace all `locator('button:has-text("Delete")').last()` with `locator('[role="dialog"] button:has-text("Delete")')` | F2 | ⬜ |
-| 6 | Replace `waitForLoadState('networkidle', ...).catch(() => null)` with `waitForResponse` scoped to `/api/applications` | F3 | ⬜ |
-| 7 | Replace `Date.now()` unique names with `uniqueCompanyName(prefix)` from helpers | F5 | ⬜ |
-
-### history.spec.ts
-
-| # | Change | Spec ID | Status |
-|---|--------|---------|--------|
-| 8 | Capture `id` from creation response in `beforeAll`; store as `applicationId` | F1 | ⬜ |
-| 9 | Replace `afterAll` UI-click cleanup with `deleteApplicationViaApi(page, applicationId)` | F1 | ⬜ |
-| 10 | Replace `locator('button:has-text("Delete")').last()` with `locator('[role="dialog"] button:has-text("Delete")')` | F2 | ⬜ |
-| 11 | Add `TODO(020-F4)` comments on Tailwind CSS class locators (`.fixed.inset-y-0.right-0`, `.space-y-1 > div`) — to be resolved in Phase 3 | F4 | ⬜ |
-
----
-
-## Phase 3 — Add data-testid to history UI components
-
-| # | File | Change | Spec ID | Status |
-|---|------|--------|---------|--------|
-| 12 | `ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ⬜ |
-| 13 | `ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ⬜ |
-| 14 | `react-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ⬜ |
-| 15 | `react-ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ⬜ |
-| 16 | `vue-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ⬜ |
-| 17 | `vue-ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ⬜ |
-| 18 | `svelte-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ⬜ |
-| 19 | `svelte-ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ⬜ |
-| 20 | `tests/e2e/history.spec.ts` | Replace Tailwind CSS locators with `[data-testid="history-panel"]` and `[data-testid="history-entry"]`; remove `TODO(020-F4)` comments | F4 | ⬜ |
-
----
-
-## Phase 4 — New test coverage
-
-| # | File | Change | Spec ID | Status |
-|---|------|--------|---------|--------|
-| 21 | `tests/e2e/filter.spec.ts` *(new)* | Create describe block with beforeAll (API: create 2 apps with different statuses), 3 filter tests (filter applied, filter interviewing, clear filter), afterAll (API delete) | C1 | ⬜ |
-| 22 | `tests/e2e/application-crud.spec.ts` | Add `describe('Interview stage edit and delete')` block: beforeAll creates app+stage via UI, test edits stage name and verifies persistence, test deletes stage and verifies removal, afterAll deletes app via API | C2 | ⬜ |
-
----
-
-## Validation
-
-| # | Command | Purpose | Status |
-|---|---------|---------|--------|
-| 23 | `npm run build:all` | No compilation errors from data-testid changes or new test files | ⬜ |
-| 24 | `npm run lint:all` | No lint regressions | ⬜ |
-| 25 | `npm run test:all` | Unit tests unaffected | ⬜ |
-| 26 | `bash scripts/run-e2e.sh all` | Full cross-stack E2E suite passes green | ⬜ |
+| 23 | `npm run build:all` | No compilation errors from data-testid changes or new test files | ✅ |
+| 24 | `npm run lint:all` | No lint regressions | ✅ |
+| 25 | `npm run test:all` | Unit tests unaffected | ✅ |
+| 26 | `bash scripts/run-e2e.sh all` | Full cross-stack E2E suite passes green | ✅ |

--- a/specs/020-e2e-test-quality/tasks.md
+++ b/specs/020-e2e-test-quality/tasks.md
@@ -1,0 +1,139 @@
+# Tasks: E2E Test Quality Improvements
+
+## Status: Complete
+
+---
+
+## Phase 1 — Shared helpers + collision-safe IDs
+
+| # | File | Change | Status |
+|---|------|--------|--------|
+| 1 | `tests/e2e/helpers.ts` *(new)* | Create with `deleteApplicationViaApi(page, id)` and `uniqueCompanyName(prefix)` helpers | ✅ |
+| 2 | `tests/e2e/csv-import-export.spec.ts` | Replace `Date.now()` unique URL with `crypto.randomUUID()` (F5) | ✅ |
+
+---
+
+## Phase 2 — Fix flaky patterns in existing test files
+
+### application-crud.spec.ts
+
+| # | Change | Spec ID | Status |
+|---|--------|---------|--------|
+| 3 | Capture `id` (not just URL) when creating test apps; store as `createdApps: { id: string; url: string }[]` | F1 | ✅ |
+| 4 | Replace `afterAll` UI-click cleanup with `deleteApplicationViaApi` loop over captured IDs | F1 | ✅ |
+| 5 | Replace all `locator('button:has-text("Delete")').last()` with `locator('[role="dialog"] button:has-text("Delete")')` | F2 | ✅ |
+| 6 | Replace `waitForLoadState('networkidle', ...).catch(() => null)` with `waitForResponse` scoped to `/api/applications` | F3 | ✅ |
+| 7 | Replace `Date.now()` unique names with `uniqueCompanyName(prefix)` from helpers | F5 | ✅ |
+
+### history.spec.ts
+
+| # | Change | Spec ID | Status |
+|---|--------|---------|--------|
+| 8 | Capture `id` from creation response in `beforeAll`; store as `applicationId` | F1 | ✅ |
+| 9 | Replace `afterAll` UI-click cleanup with `deleteApplicationViaApi(page, applicationId)` | F1 | ✅ |
+| 10 | Replace `locator('button:has-text("Delete")').last()` with `locator('[role="dialog"] button:has-text("Delete")')` | F2 | ✅ |
+| 11 | Replace Tailwind CSS class locators with `data-testid` selectors (`.fixed.inset-y-0.right-0` → `[data-testid="history-panel"]`, `.space-y-1 > div` → `[data-testid="history-entry"]`) | F4 | ✅ |
+
+---
+
+## Phase 3 — Add data-testid to history UI components
+
+| # | File | Change | Spec ID | Status |
+|---|------|--------|---------|--------|
+| 12 | `ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ✅ |
+| 13 | `ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ✅ |
+| 14 | `react-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ✅ |
+| 15 | `react-ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ✅ |
+| 16 | `vue-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ✅ |
+| 17 | `vue-ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ✅ |
+| 18 | `svelte-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ✅ |
+| 19 | `svelte-ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ✅ |
+| 20 | `tests/e2e/history.spec.ts` | Replace Tailwind CSS locators with `[data-testid="history-panel"]` and `[data-testid="history-entry"]` | F4 | ✅ |
+
+---
+
+## Phase 4 — New test coverage
+
+| # | File | Change | Spec ID | Status |
+|---|------|--------|---------|--------|
+| 21 | `tests/e2e/filter.spec.ts` *(new)* | Create describe block with beforeAll (API: create 2 apps with different statuses), 3 filter tests (filter applied, filter interviewing, clear filter), afterAll (API delete) | C1 | ✅ |
+| 22 | `tests/e2e/application-crud.spec.ts` | Add `describe('Interview stage edit and delete')` block: beforeAll creates app+stage via API, test edits stage name and verifies persistence, test deletes stage and verifies removal, afterAll deletes app via API | C2 | ✅ |
+
+---
+
+## Validation
+
+| # | Command | Purpose | Status |
+|---|---------|---------|--------|
+| 23 | `npm run build:all` | No compilation errors from data-testid changes or new test files | ⬜ |
+| 24 | `npm run lint:all` | No lint regressions | ⬜ |
+| 25 | `npm run test:all` | Unit tests unaffected | ⬜ |
+| 26 | `bash scripts/run-e2e.sh all` | Full cross-stack E2E suite passes green | ⬜ |
+
+---
+
+## Phase 1 — Shared helpers + collision-safe IDs
+
+| # | File | Change | Status |
+|---|------|--------|--------|
+| 1 | `tests/e2e/helpers.ts` *(new)* | Create with `deleteApplicationViaApi(page, id)` and `uniqueCompanyName(prefix)` helpers | ⬜ |
+| 2 | `tests/e2e/csv-import-export.spec.ts` | Replace `Date.now()` unique URL with `crypto.randomUUID()` (F5) | ⬜ |
+
+---
+
+## Phase 2 — Fix flaky patterns in existing test files
+
+### application-crud.spec.ts
+
+| # | Change | Spec ID | Status |
+|---|--------|---------|--------|
+| 3 | Capture `id` (not just URL) when creating test apps; store as `createdApps: { id: string; url: string }[]` | F1 | ⬜ |
+| 4 | Replace `afterAll` UI-click cleanup with `deleteApplicationViaApi` loop over captured IDs | F1 | ⬜ |
+| 5 | Replace all `locator('button:has-text("Delete")').last()` with `locator('[role="dialog"] button:has-text("Delete")')` | F2 | ⬜ |
+| 6 | Replace `waitForLoadState('networkidle', ...).catch(() => null)` with `waitForResponse` scoped to `/api/applications` | F3 | ⬜ |
+| 7 | Replace `Date.now()` unique names with `uniqueCompanyName(prefix)` from helpers | F5 | ⬜ |
+
+### history.spec.ts
+
+| # | Change | Spec ID | Status |
+|---|--------|---------|--------|
+| 8 | Capture `id` from creation response in `beforeAll`; store as `applicationId` | F1 | ⬜ |
+| 9 | Replace `afterAll` UI-click cleanup with `deleteApplicationViaApi(page, applicationId)` | F1 | ⬜ |
+| 10 | Replace `locator('button:has-text("Delete")').last()` with `locator('[role="dialog"] button:has-text("Delete")')` | F2 | ⬜ |
+| 11 | Add `TODO(020-F4)` comments on Tailwind CSS class locators (`.fixed.inset-y-0.right-0`, `.space-y-1 > div`) — to be resolved in Phase 3 | F4 | ⬜ |
+
+---
+
+## Phase 3 — Add data-testid to history UI components
+
+| # | File | Change | Spec ID | Status |
+|---|------|--------|---------|--------|
+| 12 | `ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ⬜ |
+| 13 | `ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ⬜ |
+| 14 | `react-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ⬜ |
+| 15 | `react-ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ⬜ |
+| 16 | `vue-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ⬜ |
+| 17 | `vue-ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ⬜ |
+| 18 | `svelte-ui/src/` — HistoryPanel component | Add `data-testid="history-panel"` to panel root element | S2 | ⬜ |
+| 19 | `svelte-ui/src/` — HistoryPanel component | Add `data-testid="history-entry"` to per-entry element | S2 | ⬜ |
+| 20 | `tests/e2e/history.spec.ts` | Replace Tailwind CSS locators with `[data-testid="history-panel"]` and `[data-testid="history-entry"]`; remove `TODO(020-F4)` comments | F4 | ⬜ |
+
+---
+
+## Phase 4 — New test coverage
+
+| # | File | Change | Spec ID | Status |
+|---|------|--------|---------|--------|
+| 21 | `tests/e2e/filter.spec.ts` *(new)* | Create describe block with beforeAll (API: create 2 apps with different statuses), 3 filter tests (filter applied, filter interviewing, clear filter), afterAll (API delete) | C1 | ⬜ |
+| 22 | `tests/e2e/application-crud.spec.ts` | Add `describe('Interview stage edit and delete')` block: beforeAll creates app+stage via UI, test edits stage name and verifies persistence, test deletes stage and verifies removal, afterAll deletes app via API | C2 | ⬜ |
+
+---
+
+## Validation
+
+| # | Command | Purpose | Status |
+|---|---------|---------|--------|
+| 23 | `npm run build:all` | No compilation errors from data-testid changes or new test files | ⬜ |
+| 24 | `npm run lint:all` | No lint regressions | ⬜ |
+| 25 | `npm run test:all` | Unit tests unaffected | ⬜ |
+| 26 | `bash scripts/run-e2e.sh all` | Full cross-stack E2E suite passes green | ⬜ |

--- a/svelte-ui/src/lib/components/ApplicationCard.svelte
+++ b/svelte-ui/src/lib/components/ApplicationCard.svelte
@@ -58,7 +58,7 @@
 </script>
 
 <div
-  class="card p-4 hover:shadow-md transition-shadow cursor-pointer {application.isArchived ? 'opacity-60' : ''}"
+  class="card p-4 min-w-0 hover:shadow-md transition-shadow cursor-pointer {application.isArchived ? 'opacity-60' : ''}"
   onclick={onclick}
   onkeydown={(e) => e.key === 'Enter' && onclick()}
   tabindex="0"

--- a/svelte-ui/src/lib/components/HistoryPanel.svelte
+++ b/svelte-ui/src/lib/components/HistoryPanel.svelte
@@ -75,7 +75,7 @@
   }
 </script>
 
-<div class="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
+<div data-testid="history-panel" class="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
   <!-- Header -->
   <div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
     <h2 class="text-lg font-semibold text-gray-900 dark:text-white">History</h2>
@@ -101,7 +101,7 @@
     {:else}
       <div class="space-y-1">
         {#each entries as entry, i (entry.id)}
-          <div>
+          <div data-testid="history-entry">
             <button
               onclick={() => toggleExpand(entry.id)}
               class="w-full text-left p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 {expandedEntry === entry.id ? 'bg-gray-50 dark:bg-gray-700/50' : ''}"

--- a/tanstack-start-ui/src/components/applications/HistoryPanel.tsx
+++ b/tanstack-start-ui/src/components/applications/HistoryPanel.tsx
@@ -67,7 +67,7 @@ export function HistoryPanel({
   }
 
   return (
-    <div className="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
+    <div data-testid="history-panel" className="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
@@ -112,7 +112,7 @@ export function HistoryPanel({
         ) : (
           <div className="space-y-1">
             {entries.map((entry, i) => (
-              <div key={entry.id}>
+              <div key={entry.id} data-testid="history-entry">
                 <button
                   onClick={() => toggleExpand(entry.id)}
                   className={`w-full text-left p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 ${

--- a/tanstack-start-ui/src/lib/queryClient.ts
+++ b/tanstack-start-ui/src/lib/queryClient.ts
@@ -3,7 +3,7 @@ import { QueryClient } from "@tanstack/react-query";
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60, // 1 minute
+      staleTime: 0,
       retry: 1,
     },
   },

--- a/tanstack-ui/src/components/applications/HistoryPanel.tsx
+++ b/tanstack-ui/src/components/applications/HistoryPanel.tsx
@@ -67,7 +67,7 @@ export function HistoryPanel({
   }
 
   return (
-    <div className="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
+    <div data-testid="history-panel" className="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
@@ -112,7 +112,7 @@ export function HistoryPanel({
         ) : (
           <div className="space-y-1">
             {entries.map((entry, i) => (
-              <div key={entry.id}>
+              <div key={entry.id} data-testid="history-entry">
                 <button
                   onClick={() => toggleExpand(entry.id)}
                   className={`w-full text-left p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 ${

--- a/tests/e2e/application-crud.spec.ts
+++ b/tests/e2e/application-crud.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { deleteApplicationViaApi, uniqueCompanyName } from './helpers';
 
 test.describe('Application CRUD - Inline Edit', () => {
-  const createdUrls: string[] = [];
+  const createdApps: { id: string; url: string }[] = [];
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
@@ -35,7 +36,8 @@ test.describe('Application CRUD - Inline Edit', () => {
 
     await page.click('button:has-text("Create Application")');
     await page.waitForURL(/\/applications\/[a-f0-9-]+$/);
-    createdUrls.push(page.url());
+    const id1 = page.url().split('/').pop()!;
+    createdApps.push({ id: id1, url: page.url() });
 
     await expect(page.locator('input[placeholder="Company Name *"]')).toHaveValue('E2E Test Company');
     await expect(page.locator('input[placeholder="Position Title *"]')).toHaveValue('Senior Engineer');
@@ -50,7 +52,8 @@ test.describe('Application CRUD - Inline Edit', () => {
     await page.selectOption('#status', 'applied');
     await page.click('button:has-text("Create Application")');
     await page.waitForURL(/\/applications\/[a-f0-9-]+$/);
-    createdUrls.push(page.url());
+    const id2 = page.url().split('/').pop()!;
+    createdApps.push({ id: id2, url: page.url() });
 
     const companyInput = page.locator('input[placeholder="Company Name *"]');
     await companyInput.clear();
@@ -76,7 +79,8 @@ test.describe('Application CRUD - Inline Edit', () => {
     await page.fill('input[placeholder="Position Title *"]', 'Tester');
     await page.click('button:has-text("Create Application")');
     await page.waitForURL(/\/applications\/[a-f0-9-]+$/);
-    createdUrls.push(page.url());
+    const id3 = page.url().split('/').pop()!;
+    createdApps.push({ id: id3, url: page.url() });
 
     const companyInput = page.locator('input[placeholder="Company Name *"]');
     await companyInput.clear();
@@ -84,8 +88,8 @@ test.describe('Application CRUD - Inline Edit', () => {
 
     await page.click('button:has-text("Discard")');
 
-    // Confirm discard in the dialog (use .last() to target the dialog's button)
-    await page.locator('button:has-text("Discard")').last().click();
+    // Confirm discard in the dialog
+    await page.locator('[role="dialog"] button:has-text("Discard")').click();
 
     await expect(page.locator('input[placeholder="Company Name *"]')).toHaveValue('Discard Test Company');
   });
@@ -107,13 +111,14 @@ test.describe('Application CRUD - Inline Edit', () => {
 
     await page.click('button:has-text("Create Application")');
     await page.waitForURL(/\/applications\/[a-f0-9-]+$/);
-    createdUrls.push(page.url());
+    const id4 = page.url().split('/').pop()!;
+    createdApps.push({ id: id4, url: page.url() });
 
     await expect(page.locator('text=Phone Screen')).toBeVisible();
   });
 
   test('should delete an application', async ({ page }) => {
-    const uniqueName = `Delete Co ${Date.now()}`;
+    const uniqueName = uniqueCompanyName('Delete Co');
     await page.goto('/applications/new');
     await page.waitForLoadState('domcontentloaded');
     await page.fill('input[placeholder="Company Name *"]', uniqueName);
@@ -123,8 +128,8 @@ test.describe('Application CRUD - Inline Edit', () => {
 
     await page.click('button:has-text("Delete")');
 
-    // Confirm deletion in the dialog (use .last() to target the dialog's button, not the header's)
-    await page.locator('button:has-text("Delete")').last().click();
+    // Confirm deletion in the dialog
+    await page.locator('[role="dialog"] button:has-text("Delete")').click();
 
     await page.waitForURL('/');
 
@@ -173,7 +178,8 @@ test.describe('Application CRUD - Inline Edit', () => {
 
     await page.click('button:has-text("Create Application")');
     await page.waitForURL(/\/applications\/[a-f0-9-]+$/);
-    createdUrls.push(page.url());
+    const id5 = page.url().split('/').pop()!;
+    createdApps.push({ id: id5, url: page.url() });
 
     // Verify date field is empty on the edit page (null dateApplied)
     await expect(page.locator('#dateApplied')).toHaveValue('');
@@ -272,16 +278,11 @@ test.describe('Application CRUD - Inline Edit', () => {
   });
 
   test.afterAll(async ({ browser }) => {
-    if (createdUrls.length === 0) return;
+    if (createdApps.length === 0) return;
     const context = await browser.newContext();
     const page = await context.newPage();
-    for (const url of createdUrls) {
-      await page.goto(url);
-      await page.waitForLoadState('domcontentloaded');
-      await page.waitForSelector('input[placeholder="Company Name *"]', { timeout: 10000 });
-      await page.click('button:has-text("Delete")');
-      await page.locator('button:has-text("Delete")').last().click();
-      await page.waitForURL('/');
+    for (const { id } of createdApps) {
+      await deleteApplicationViaApi(page, id);
     }
     await context.close();
   });
@@ -319,10 +320,13 @@ test.describe('Status label - Not a match', () => {
     });
 
     await page.goto('/');
-    // Wait for networkidle so that React (SSR/hydration) and framework data fetches are fully settled
+    // Wait for the initial applications API response so that React SSR/hydration is settled
     // before interacting with the filter. This ensures selectOption() properly triggers onChange
     // handlers on React-based stacks (e.g. tanstack-start), which only work post-hydration.
-    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => null);
+    await page.waitForResponse(
+      (r) => r.url().includes('/api/applications') && r.status() === 200,
+      { timeout: 15000 },
+    ).catch(() => null);
 
     // Apply status filter if the UI supports it — ensures visibility even if parallel test activity
     // pushed this app off page 1 after the re-PATCH above.
@@ -415,5 +419,125 @@ test.describe('Date display in list - angular-spring-ui', () => {
     // NOT "56 years ago" which indicates epoch/array date parsing failure
     await expect(updatedCell).not.toContainText('years ago');
     await expect(updatedCell).toContainText(/just now|\d+ (minute|hour)s? ago/);
+  });
+});
+
+test.describe('Interview stage edit and delete', () => {
+  let stageAppId: string;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    // Create application with one stage via API
+    const res = await page.request.post('/api/applications', {
+      data: { companyName: uniqueCompanyName('Stage Edit Co'), positionTitle: 'Engineer' },
+    });
+    const app = await res.json();
+    stageAppId = app.id;
+    // Add a stage via API (include order:0 for stacks that require it, e.g. koa-api)
+    await page.request.post(`/api/applications/${stageAppId}/interview-stages`, {
+      data: { name: 'Original Stage Name', order: 0 },
+    });
+    await context.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    if (!stageAppId) return;
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await deleteApplicationViaApi(page, stageAppId);
+    await context.close();
+  });
+
+  test('should edit a stage name and persist the update', async ({ page }) => {
+    await page.goto(`/applications/${stageAppId}`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForSelector('text=Original Stage Name', { timeout: 10000 });
+
+    // Open stage edit — try aria-label first (ui/), then title, then "Edit" text
+    const editByAriaLabel = page.locator('button[aria-label="Edit Original Stage Name"]');
+    const editByTitle = page.locator('button[title="Edit stage"]');
+    const editByText = page.locator('button:has-text("Edit")').first();
+
+    if (await editByAriaLabel.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await editByAriaLabel.click();
+    } else if (await editByTitle.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await editByTitle.click();
+    } else if (await editByText.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await editByText.click();
+    } else {
+      test.skip(true, 'Stage edit mechanism not recognized on this stack');
+      return;
+    }
+
+    // Update the stage name (StageForm: visible when form is in edit mode)
+    const nameInput = page.locator('input[placeholder="e.g., Technical Interview"]');
+    const hasStageForm = await nameInput.isVisible({ timeout: 2000 }).catch(() => false);
+    if (!hasStageForm) {
+      test.skip(true, 'Stage form not available on this stack');
+      return;
+    }
+
+    await nameInput.fill('Updated Stage Name');
+
+    // Click Save Changes — uses direct onClick handler (bypasses webkit form submit events)
+    await page.locator('[data-testid="stage-form-save"]').click();
+
+    // Wait for the form to close (async save: PATCH + reload) before checking text
+    await expect(nameInput).not.toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Updated Stage Name')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('text=Original Stage Name')).not.toBeVisible();
+
+    // Reload to confirm persistence
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('text=Updated Stage Name')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should delete a stage and verify removal', async ({ page }) => {
+    await page.goto(`/applications/${stageAppId}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    // Skip if edit test was skipped (stage name was never updated on this stack)
+    const hasUpdatedName = await page.locator('text=Updated Stage Name').isVisible({ timeout: 5000 }).catch(() => false);
+    if (!hasUpdatedName) {
+      test.skip(true, 'Stage was not renamed (edit test skipped or not supported on this stack)');
+      return;
+    }
+
+    // Open stage edit
+    const editByAriaLabel = page.locator('button[aria-label="Edit Updated Stage Name"]');
+    const editByTitle = page.locator('button[title="Edit stage"]');
+    const editByText = page.locator('button:has-text("Edit")').first();
+
+    if (await editByAriaLabel.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await editByAriaLabel.click();
+    } else if (await editByTitle.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await editByTitle.click();
+    } else if (await editByText.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await editByText.click();
+    } else {
+      test.skip(true, 'Stage edit mechanism not recognized on this stack');
+      return;
+    }
+
+    const nameInput = page.locator('input[placeholder="e.g., Technical Interview"]');
+    const hasStageForm = await nameInput.isVisible({ timeout: 2000 }).catch(() => false);
+    if (!hasStageForm) {
+      test.skip(true, 'Stage form not available on this stack');
+      return;
+    }
+
+    // Click Delete Stage in the stage form
+    const stageForm = page.locator('form:has(input[placeholder="e.g., Technical Interview"])');
+    await stageForm.locator('button:has-text("Delete Stage")').click();
+
+    // Confirm deletion in dialog if one appears
+    const confirmDelete = page.locator('[role="dialog"] button:has-text("Delete")');
+    if (await confirmDelete.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await confirmDelete.click();
+    }
+
+    await expect(page.locator('text=Updated Stage Name')).not.toBeVisible({ timeout: 10000 });
   });
 });

--- a/tests/e2e/application-crud.spec.ts
+++ b/tests/e2e/application-crud.spec.ts
@@ -422,7 +422,7 @@ test.describe('Date display in list - angular-spring-ui', () => {
   });
 });
 
-test.describe('Interview stage edit and delete', () => {
+test.describe.serial('Interview stage edit and delete', () => {
   let stageAppId: string;
 
   test.beforeAll(async ({ browser }) => {

--- a/tests/e2e/csv-import-export.spec.ts
+++ b/tests/e2e/csv-import-export.spec.ts
@@ -135,10 +135,8 @@ test.describe('CSV Import/Export', () => {
     await page.click('button:has-text("Close")');
   });
 
-  test('should show skipped count for duplicate URLs', async ({ page }, testInfo) => {
-    // Use a unique ID per worker+run for both the URL and filename to avoid cross-browser
-    // race conditions — multiple browser projects can share the same workerIndex
-    const uniqueId = `${testInfo.workerIndex}-${Date.now()}`;
+  test('should show skipped count for duplicate URLs', async ({ page }) => {
+    const uniqueId = crypto.randomUUID();
     const uniqueUrl = `https://e2e-dedup-test-unique.com/jobs/${uniqueId}`;
     const csv1 = [
       'companyName,positionTitle,dateApplied,status,companyUrl,jobPostingUrl,companyCareerUrl,companyCategory,skillsMatch,jobSource,coverLetterRequired,specialRequirements,salaryMin,salaryMax,notes,offerDueDate',

--- a/tests/e2e/csv-import-export.spec.ts
+++ b/tests/e2e/csv-import-export.spec.ts
@@ -155,6 +155,10 @@ test.describe('CSV Import/Export', () => {
     // Verify the first import actually created the app — if imported=0 the dedup test is invalid
     await expect(page.locator('text=Imported').locator('..')).toContainText(/\b1(?!\d)/);
     await page.click('button:has-text("Close")');
+    // Wait for the import panel to fully close before starting second import.
+    // Without this, webkit can find the stale first-import result (skipped:0)
+    // before the panel re-opens and the second import completes.
+    await expect(page.locator('text=Import Applications')).not.toBeVisible({ timeout: 5000 });
 
     // Second import with same URL — should be skipped
     await page.click('button:has-text("Import CSV")');

--- a/tests/e2e/filter.spec.ts
+++ b/tests/e2e/filter.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { deleteApplicationViaApi, uniqueCompanyName } from './helpers';
+
+// Filter tests run against all stacks that expose a status filter select.
+// Stacks without a filter UI will skip gracefully via the isVisible check.
+
+test.describe.serial('List filter by status', () => {
+  let appliedAppId: string;
+  let interviewingAppId: string;
+  const appliedCompany = uniqueCompanyName('Filter Applied Co');
+  const interviewingCompany = uniqueCompanyName('Filter Interviewing Co');
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    const res1 = await page.request.post('/api/applications', {
+      data: { companyName: appliedCompany, positionTitle: 'Engineer' },
+    });
+    const app1 = await res1.json();
+    appliedAppId = app1.id;
+    // Include all required fields in PATCH so backends that require full body (e.g. Go, Spring) also work.
+    await page.request.patch(`/api/applications/${appliedAppId}`, {
+      data: { companyName: appliedCompany, positionTitle: 'Engineer', status: 'applied' },
+    });
+
+    const res2 = await page.request.post('/api/applications', {
+      data: { companyName: interviewingCompany, positionTitle: 'Engineer' },
+    });
+    const app2 = await res2.json();
+    interviewingAppId = app2.id;
+    await page.request.patch(`/api/applications/${interviewingAppId}`, {
+      data: { companyName: interviewingCompany, positionTitle: 'Engineer', status: 'interviewing' },
+    });
+
+    await context.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    if (appliedAppId) await deleteApplicationViaApi(page, appliedAppId);
+    if (interviewingAppId) await deleteApplicationViaApi(page, interviewingAppId);
+    await context.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForSelector('h1', { timeout: 10000 });
+    // Wait for both test companies to appear in the unfiltered list.
+    // This confirms the initial data-load API call has completed before each
+    // test starts, so subsequent filter actions don't race with the page-load response.
+    await page.waitForSelector(`text=${appliedCompany}`, { timeout: 10000 });
+    await page.waitForSelector(`text=${interviewingCompany}`, { timeout: 10000 });
+  });
+
+  test('filter applied — only applied apps visible', async ({ page }) => {
+    const statusSelect = page.locator('select:has(option[value="applied"])').first();
+    const filterPresent = await statusSelect.isVisible({ timeout: 2000 }).catch(() => false);
+    test.skip(!filterPresent, 'Status filter not available on this stack');
+
+    await statusSelect.selectOption('applied');
+
+    // Check the company that should DISAPPEAR first (longer timeout confirms filter applied).
+    // Only then verify the remaining company is still present.
+    await expect(page.locator(`text=${interviewingCompany}`)).not.toBeVisible({ timeout: 10000 });
+    await expect(page.locator(`text=${appliedCompany}`).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('filter interviewing — only interviewing apps visible', async ({ page }) => {
+    const statusSelect = page.locator('select:has(option[value="interviewing"])').first();
+    const filterPresent = await statusSelect.isVisible({ timeout: 2000 }).catch(() => false);
+    test.skip(!filterPresent, 'Status filter not available on this stack');
+
+    await statusSelect.selectOption('interviewing');
+
+    await expect(page.locator(`text=${appliedCompany}`)).not.toBeVisible({ timeout: 10000 });
+    await expect(page.locator(`text=${interviewingCompany}`).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('clear filter — both apps visible', async ({ page }) => {
+    const statusSelect = page.locator('select:has(option[value="applied"])').first();
+    const filterPresent = await statusSelect.isVisible({ timeout: 2000 }).catch(() => false);
+    test.skip(!filterPresent, 'Status filter not available on this stack');
+
+    // Apply a filter first, wait for the list to update
+    await statusSelect.selectOption('applied');
+    await expect(page.locator(`text=${interviewingCompany}`)).not.toBeVisible({ timeout: 10000 });
+
+    // Clear the filter (first option "" = all), wait for both to appear
+    await statusSelect.selectOption('');
+    await expect(page.locator(`text=${appliedCompany}`).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator(`text=${interviewingCompany}`).first()).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,15 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Delete an application via the API. Call from afterAll to avoid UI-based cleanup.
+ */
+export async function deleteApplicationViaApi(page: Page, id: string): Promise<void> {
+  await page.request.delete(`/api/applications/${id}`);
+}
+
+/**
+ * UUID-based unique company name to avoid parallel-test collisions.
+ */
+export function uniqueCompanyName(prefix: string): string {
+  return `${prefix} ${crypto.randomUUID()}`;
+}

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -4,7 +4,9 @@ import type { Page } from '@playwright/test';
  * Delete an application via the API. Call from afterAll to avoid UI-based cleanup.
  */
 export async function deleteApplicationViaApi(page: Page, id: string): Promise<void> {
-  await page.request.delete(`/api/applications/${id}`);
+  const response = await page.request.delete(`/api/applications/${id}`);
+  if (response.ok() || response.status() === 404) return;
+  throw new Error(`Failed to delete application ${id}: ${response.status()} ${response.statusText()}`);
 }
 
 /**

--- a/tests/e2e/history.spec.ts
+++ b/tests/e2e/history.spec.ts
@@ -1,15 +1,17 @@
 import { test, expect, type Page } from '@playwright/test';
+import { deleteApplicationViaApi, uniqueCompanyName } from './helpers';
 
 // Shared history tests for all stacks with history support:
 // Next.js+Express (port 3000), React+Koa (port 3010), Vue+Nuxt (port 3020), Svelte+Hono (port 3030).
 
 test.describe.serial('History Panel', () => {
   let applicationUrl: string;
-  const uniqueCompany = `History Co ${Date.now()}`;
-  const uniquePosition = `Engineer ${Date.now()}`;
+  let applicationId: string;
+  const uniqueCompany = uniqueCompanyName('History Co');
+  const uniquePosition = uniqueCompanyName('Engineer');
 
-  const panel = (page: Page): ReturnType<Page['locator']> => page.locator('.fixed.inset-y-0.right-0');
-  const entries = (page: Page): ReturnType<Page['locator']> => panel(page).locator('.space-y-1 > div');
+  const panel = (page: Page): ReturnType<Page['locator']> => page.locator('[data-testid="history-panel"]');
+  const entries = (page: Page): ReturnType<Page['locator']> => panel(page).locator('[data-testid="history-entry"]');
 
   async function createApplication(page: Page, company: string, position: string): Promise<string> {
     await page.goto('/applications/new');
@@ -18,6 +20,7 @@ test.describe.serial('History Panel', () => {
     await page.fill('input[placeholder="Position Title *"]', position);
     await page.click('button:has-text("Create Application")');
     await page.waitForURL(/\/applications\/[a-f0-9-]+$/);
+    applicationId = page.url().split('/').pop()!;
     return page.url();
   }
 
@@ -154,15 +157,10 @@ test.describe.serial('History Panel', () => {
   });
 
   test.afterAll(async ({ browser }) => {
-    if (!applicationUrl) return;
+    if (!applicationId) return;
     const context = await browser.newContext();
     const page = await context.newPage();
-    await page.goto(applicationUrl);
-    await page.waitForLoadState('domcontentloaded');
-    await page.waitForSelector('input[placeholder="Company Name *"]', { timeout: 10000 });
-    await page.click('button:has-text("Delete")');
-    await page.locator('button:has-text("Delete")').last().click();
-    await page.waitForURL('/');
+    await deleteApplicationViaApi(page, applicationId);
     await context.close();
   });
 });

--- a/ui/src/components/applications/ApplicationEdit.tsx
+++ b/ui/src/components/applications/ApplicationEdit.tsx
@@ -162,8 +162,8 @@ export function ApplicationEdit({ applicationId }: ApplicationEditProps): React.
   // ---------------------------------------------------------------------------
   // Load application (edit mode)
   // ---------------------------------------------------------------------------
-  const loadApplication = useCallback(async (id: string): Promise<void> => {
-    setIsLoading(true);
+  const loadApplication = useCallback(async (id: string, silent = false): Promise<void> => {
+    if (!silent) setIsLoading(true);
     setFetchError(null);
     try {
       const app = await applicationsApi.get(id) as JobApplication;
@@ -175,7 +175,7 @@ export function ApplicationEdit({ applicationId }: ApplicationEditProps): React.
       const message = err instanceof Error ? err.message : 'Failed to load application';
       setFetchError(message);
     } finally {
-      setIsLoading(false);
+      if (!silent) setIsLoading(false);
     }
   }, []);
 
@@ -417,7 +417,7 @@ export function ApplicationEdit({ applicationId }: ApplicationEditProps): React.
           performanceRating: data.performanceRating || undefined,
         });
         // Reload application to get updated stages
-        await loadApplication(applicationId);
+        await loadApplication(applicationId, true);
         setHistoryKey((k) => k + 1);
         setShowStageForm(false);
       } catch (err: unknown) {
@@ -454,7 +454,7 @@ export function ApplicationEdit({ applicationId }: ApplicationEditProps): React.
 
         if (Object.keys(update).length > 0) {
           await stagesApi.update(applicationId, editingStage.id, update);
-          await loadApplication(applicationId);
+          await loadApplication(applicationId, true);
           setHistoryKey((k) => k + 1);
         }
         setEditingStage(null);
@@ -487,7 +487,7 @@ export function ApplicationEdit({ applicationId }: ApplicationEditProps): React.
     if (isEditMode && applicationId) {
       try {
         await stagesApi.delete(applicationId, editingStage.id);
-        await loadApplication(applicationId);
+        await loadApplication(applicationId, true);
         setHistoryKey((k) => k + 1);
       } catch (err: unknown) {
         logger.error('Failed to delete interview stage:', err);
@@ -512,7 +512,7 @@ export function ApplicationEdit({ applicationId }: ApplicationEditProps): React.
     if (isEditMode && applicationId) {
       try {
         await stagesApi.update(applicationId, stageId, update);
-        await loadApplication(applicationId);
+        await loadApplication(applicationId, true);
         setHistoryKey((k) => k + 1);
       } catch (err: unknown) {
         logger.error('Failed to toggle stage completion:', err);

--- a/ui/src/components/applications/HistoryPanel.tsx
+++ b/ui/src/components/applications/HistoryPanel.tsx
@@ -85,7 +85,7 @@ export function HistoryPanel({ applicationId, refreshKey, onClose, onRestored }:
   }
 
   return (
-    <div className="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
+    <div data-testid="history-panel" className="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-white">History</h2>
@@ -115,7 +115,7 @@ export function HistoryPanel({ applicationId, refreshKey, onClose, onRestored }:
         ) : (
           <div className="space-y-1">
             {entries.map((entry, i) => (
-              <div key={entry.id}>
+              <div key={entry.id} data-testid="history-entry">
                 <button
                   onClick={() => toggleExpand(entry.id)}
                   className={`w-full text-left p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 ${

--- a/ui/src/components/interviews/InterviewChecklist.test.tsx
+++ b/ui/src/components/interviews/InterviewChecklist.test.tsx
@@ -57,9 +57,8 @@ describe('InterviewChecklist', () => {
       fireEvent.change(nameInput, { target: { value: 'Onsite' } });
 
       // Submit the form
-      const form = nameInput.closest('form');
-      const submitButton = form?.querySelector('button[type="submit"]');
-      fireEvent.click(submitButton!);
+      const submitButton = screen.getByTestId('stage-form-save') as HTMLElement;
+      fireEvent.click(submitButton);
 
       // Wait for the modal to close (which means form submission completed)
       await waitFor(() => {

--- a/ui/src/components/interviews/StageForm.tsx
+++ b/ui/src/components/interviews/StageForm.tsx
@@ -74,9 +74,7 @@ export function StageForm({
     }));
   };
 
-  const handleSubmit = (e: FormEvent): void => {
-    e.preventDefault();
-
+  const doSubmit = (): void => {
     const validation = validateInterviewStage(formData);
 
     if (!validation.isValid) {
@@ -99,8 +97,13 @@ export function StageForm({
     onSubmit(cleanData);
   };
 
+  const handleSubmit = (e: FormEvent): void => {
+    e.preventDefault();
+    doSubmit();
+  };
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} noValidate className="space-y-4">
       <Input
         label="Stage Name"
         name="name"
@@ -197,7 +200,7 @@ export function StageForm({
           <Button type="button" variant="secondary" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit">
+          <Button type="button" data-testid="stage-form-save" onClick={doSubmit}>
             {mode === 'create' ? 'Add Stage' : 'Save Changes'}
           </Button>
         </div>

--- a/ui/src/services/validation.ts
+++ b/ui/src/services/validation.ts
@@ -118,7 +118,7 @@ export function validateInterviewStage(input: InterviewStageInput): ValidationRe
   }
 
   // Performance rating validation
-  if (input.performanceRating !== undefined) {
+  if (input.performanceRating != null) {
     if (
       input.performanceRating < VALIDATION_LIMITS.performanceRating.min ||
       input.performanceRating > VALIDATION_LIMITS.performanceRating.max

--- a/vue-ui/src/components/HistoryPanel.vue
+++ b/vue-ui/src/components/HistoryPanel.vue
@@ -83,7 +83,10 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
+  <div
+    data-testid="history-panel"
+    class="fixed inset-y-0 right-0 w-96 z-40 bg-white dark:bg-gray-800 shadow-xl border-l border-gray-200 dark:border-gray-700 flex flex-col"
+  >
     <!-- Header -->
     <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
       <div class="flex items-center gap-2">
@@ -128,6 +131,7 @@ onMounted(() => {
         <div
           v-for="commit in commits"
           :key="commit.id"
+          data-testid="history-entry"
           class="border border-gray-100 dark:border-gray-700 rounded-lg"
           :class="isCurrentVersion(commit) ? 'bg-primary-50 dark:bg-primary-900/20 border-primary-200 dark:border-primary-800' : 'bg-white dark:bg-gray-800'"
         >


### PR DESCRIPTION
## Summary

- **New E2E tests**: \`filter.spec.ts\` for status filter UI + \`helpers.ts\` with shared utilities; \`history.spec.ts\` and \`application-crud.spec.ts\` hardened with \`test.describe.serial\`, better selectors, and cross-stack timing fixes
- **Go API fixes**: removed \`binding:"required"\` from \`ApplicationInput\` (blocked partial PATCH), fixed \`StageInput\` JSON keys from \`stageName\`/\`stageOrder\` → \`name\`/\`order\` to match the OpenAPI spec and all other backends; added \`ErrValidation\` sentinel so handler returns 400 for input errors and 500 for DB errors
- **Missing \`data-testid\`s**: added \`history-panel\` and \`history-entry\` testids to all 8 stacks
- **Angular confirm dialogs**: added \`role="dialog"\` to inner div so Playwright \`[role="dialog"]\` locators work
- **svelte-ui**: added \`min-w-0\` to \`ApplicationCard\` root div to fix webkit grid overflow at narrow viewports
- **tanstack-start-ui**: set \`staleTime: 0\` on SSR singleton \`queryClient\` so newly created test records aren't hidden by cache
- **angular-ui service**: fixed \`addStage\`/\`updateStage\` payload keys to use \`name\`/\`order\`
- **VS Code**: removed broken \`Spring API (Launch)\` launch config; added \`dev:spring-api:debug\` npm script for attach-based debugging
- **CLAUDE.md**: documented E2E patterns, Angular \`role="dialog"\` requirement, and launch.json guidance; fixed \`--grep-invert\` flag (was incorrectly documented as \`rg --invert-match\`)

### Copilot review fixes (follow-up commit)
- \`deleteApplicationViaApi\` now throws on unexpected response status (tolerates 404)
- Stage edit/delete \`describe\` changed to \`test.describe.serial\` — delete test depends on edit having renamed the stage
- Go \`createApplication\` handler: added \`ErrValidation\` sentinel type; returns 500 for DB errors, 400 only for validation errors

### webkit CSV import dedup fixes (follow-up commit)
- **angular-spring-ui** \`csv-import.component.ts\`: replaced \`[hidden]="!result()"\` with \`@if (result())\` — webkit was resolving \`toBeVisible()\` on the hidden-but-present element (skipped:0 default) before the second import completed
- **shared E2E test**: added \`await expect(page.locator('text=Import Applications')).not.toBeVisible()\` after first-import Close click — ensures the panel fully closes before the second import starts, fixing a webkit timing race on tanstack-ui

## Test Plan

- [x] Full E2E suite passes across all 8 stacks
- [x] Go API unit tests updated for new \`name\`/\`order\` stage payload keys
- [x] Filter tests pass on stacks with filter UI; gracefully skip on those without
- [x] Go build clean after \`ErrValidation\` sentinel addition
- [x] CSV import dedup test passes on all webkit stacks (angular-spring-ui, tanstack-ui, angular-ui)

🤖 Generated with [Claude Code](https://claude.com/claude-code)