### PR TITLE
docs: add pr-comments skill

### DIFF
--- a/.agent/skills/pr-comments
+++ b/.agent/skills/pr-comments
@@ -1,0 +1,1 @@
+../../.agents/skills/pr-comments

--- a/.agents/skills/js-deps/SKILL.md
+++ b/.agents/skills/js-deps/SKILL.md
@@ -34,13 +34,13 @@ Create an isolated git worktree so the main working directory is never modified:
 ```bash
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 BRANCH_NAME="js-deps-$TIMESTAMP"
-WORKTREE_PATH="${TMPDIR:-/tmp}/$BRANCH_NAME"
+WORKTREE_PATH="$(git rev-parse --show-toplevel)/../$BRANCH_NAME"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME"
 ```
 
 If `git worktree add` fails (e.g., sandbox permission error), prompt the user:
-> `git worktree` requires write access to `$TMPDIR`. Choose an option:
-> 1. Add `$TMPDIR` to your sandbox allowlist in `settings.json` (recommended)
+> `git worktree` requires write access outside the project root. Choose an option:
+> 1. Add the parent directory (one level above the repo root) to your sandbox allowlist in `settings.json` (recommended)
 > 2. Fall back to branch+stash approach
 
 **All subsequent steps operate within `$WORKTREE_PATH`.** Discovery, installs, edits, and commits all happen there. Paths like `cd <directory>` in reference files are relative to `$WORKTREE_PATH`.
@@ -137,3 +137,10 @@ fi
 - **Lockfile sync**: After all package.json changes, run `$PM install` in every modified directory and commit lockfiles — CI tools like `npm ci` require exact sync between package.json and the lockfile
 - **Verify devDependencies placement**: After bulk installs across directories, verify that linting/testing/build packages (eslint, typescript, vite, etc.) ended up in `devDependencies`, not `dependencies` — easy to misplace when running install commands across many directories
 - **Monorepo workspace root**: If a discovered `package.json` has a `workspaces` field but no `dependencies` or `devDependencies`, it is a workspace root acting only as an orchestrator. Run `$PM audit` or `$PM outdated` from the root (which covers all workspaces) rather than processing member directories individually. For npm 7+, use `npm audit --workspaces` and `npm install --workspaces` to operate on all workspaces at once.
+- **Corrupted npm lockfile (temp paths)**: If `package-lock.json` contains absolute temp paths (e.g. `/private/tmp/...` or `/var/folders/...`) and many `"extraneous": true` entries after `npm install`, `npm ci` will fail in CI with platform errors (e.g. `EBADPLATFORM`). Detect and fix after each install:
+  ```bash
+  if grep -qE '/private/tmp|/var/folders' "$DIR/package-lock.json" 2>/dev/null; then
+    rm -rf "$DIR/node_modules" "$DIR/package-lock.json"
+    cd "$DIR" && npm install
+  fi
+  ```

--- a/.agents/skills/js-deps/SKILL.md
+++ b/.agents/skills/js-deps/SKILL.md
@@ -34,7 +34,7 @@ Create an isolated git worktree so the main working directory is never modified:
 ```bash
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 BRANCH_NAME="js-deps-$TIMESTAMP"
-WORKTREE_PATH="$(git rev-parse --show-toplevel)/../$BRANCH_NAME"
+WORKTREE_PATH="$(dirname "$(git rev-parse --show-toplevel)")/$BRANCH_NAME"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME"
 ```
 
@@ -141,6 +141,6 @@ fi
   ```bash
   if grep -qE '/private/tmp|/var/folders' "$DIR/package-lock.json" 2>/dev/null; then
     rm -rf "$DIR/node_modules" "$DIR/package-lock.json"
-    cd "$DIR" && npm install
+    (cd "$DIR" && npm install)
   fi
   ```

--- a/.agents/skills/js-deps/references/audit-workflow.md
+++ b/.agents/skills/js-deps/references/audit-workflow.md
@@ -25,6 +25,10 @@ Collect all audit results into a consolidated report.
 
 If `$ARGUMENTS` contains specific package names or glob patterns (not `.` or empty), filter the vulnerability list to only those packages before applying fixes.
 
+### Early Exit: No Vulnerabilities
+
+After collecting audit results across all directories, if the total vulnerability count is zero, report that the project is clean and exit — do not commit, push, or create a PR.
+
 ### Categorize by Severity
 
 Parse audit results for each directory:
@@ -59,6 +63,8 @@ npm audit fix
 This handles transitive dependency chains automatically. Only proceed to manual updates below if `npm audit fix` reports remaining vulnerabilities.
 
 > **Note:** `npm audit fix` fixes all vulnerabilities regardless of `$ARGUMENTS` scope. If specific packages were requested, verify afterwards that only those packages were modified and revert any unintended changes using the revert block in SKILL.md step 7.
+>
+> **Never use `npm audit fix --force`.** The `--force` flag installs breaking major version upgrades non-interactively, bypassing the validation logic in SKILL.md step 7. If `npm audit fix` leaves remaining vulnerabilities, fall back to manual updates below.
 
 For pnpm 8+, automated fix is also available:
 ```bash

--- a/.agents/skills/js-deps/references/update-workflow.md
+++ b/.agents/skills/js-deps/references/update-workflow.md
@@ -66,7 +66,7 @@ For yarn: `audit fix` is not available — fix remaining vulnerabilities manuall
 
 1. Commit changes. Choose the message based on what was updated:
    - Patch/minor only: `"chore: update dependencies"`
-   - Major bumps included: `"chore: update dependencies (major: pkg1 vX→Y, pkg2 vX→Y)"`
+   - Major bumps included: `"chore: update dependencies (major: pkg1 vX->Y, pkg2 vX->Y)"`
    ```bash
    git -C "$WORKTREE_PATH" add -A
    git -C "$WORKTREE_PATH" commit -m "<message from above>"

--- a/.agents/skills/js-deps/references/update-workflow.md
+++ b/.agents/skills/js-deps/references/update-workflow.md
@@ -16,6 +16,8 @@ Run the outdated check to get a list of packages to update. See [package-manager
 
 Filter the results based on any version preferences expressed by the user — whether from the interactive help flow or from inline request phrasing (e.g., "only patch updates", "skip major versions").
 
+If no packages are outdated after filtering, report that all packages are up to date and exit — do not commit, push, or create a PR.
+
 The tiered filter model works as follows:
 
 - **"Patch only"**: include packages where only the patch version differs (major and minor are the same).
@@ -62,10 +64,12 @@ For yarn: `audit fix` is not available — fix remaining vulnerabilities manuall
 
 ### On Success
 
-1. Commit changes:
+1. Commit changes. Choose the message based on what was updated:
+   - Patch/minor only: `"chore: update dependencies"`
+   - Major bumps included: `"chore: update dependencies (major: pkg1 vX→Y, pkg2 vX→Y)"`
    ```bash
    git -C "$WORKTREE_PATH" add -A
-   git -C "$WORKTREE_PATH" commit -m "chore: update dependencies"
+   git -C "$WORKTREE_PATH" commit -m "<message from above>"
    # If commit fails due to GPG signing, retry with --no-gpg-sign
    ```
 2. Push branch to remote:
@@ -93,7 +97,8 @@ For yarn: `audit fix` is not available — fix remaining vulnerabilities manuall
 
    Generated with [Claude Code](https://claude.com/claude-code)
    PREOF
-   gh pr create --title "chore: update dependencies" --body-file "$BODY_FILE"
+   # Use the same title as the commit message chosen above
+   gh pr create --title "<commit message from step 1>" --body-file "$BODY_FILE"
    rm -f "$BODY_FILE"
    ```
 4. Return the PR URL to the user

--- a/.agents/skills/pr-comments/SKILL.md
+++ b/.agents/skills/pr-comments/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: pr-comments
+description: >-
+  Address review comments on your own pull request: implement valid suggestions,
+  reply to invalid ones, and resolve threads. Use when: user says "address PR
+  comments", "implement PR feedback", "respond to review comments", "handle
+  review feedback", "process PR review comments", or wants to work through open
+  review threads on their pull request. Gives credit to commenters in commit messages.
+license: MIT
+compatibility: Requires git and GitHub CLI (gh) with authentication
+metadata:
+  author: Gregory Murray
+  repository: github.com/whatifwedigdeeper/agent-skills
+  version: "1.0"
+---
+
+# PR Review: Implement and Respond to Review Comments
+
+Work through open PR review threads — implement valid suggestions, explain why invalid ones won't be addressed, and close the loop by resolving threads and committing with commenter credit.
+
+## Arguments
+
+Optional PR number (e.g. `42`). If omitted, detect from the current branch.
+
+If `$ARGUMENTS` is `help`, `--help`, `-h`, or `?`, print usage and exit.
+
+## Tool choice rationale
+
+Different operations require different `gh` commands:
+
+| Task | Command | Why |
+|------|---------|-----|
+| PR metadata | `gh pr view --json` | High-level; handles branch detection |
+| List review comments | `gh api repos/{owner}/{repo}/pulls/{number}/comments` | REST; simpler than GraphQL for reads |
+| Reply to a comment | `gh api repos/{owner}/{repo}/pulls/comments/{id}/replies` | REST; direct reply-to-comment endpoint |
+| Get thread node IDs | `gh api graphql` | Thread node IDs only exist in GraphQL |
+| Resolve a thread | `gh api graphql` mutation | No REST equivalent for resolution |
+
+## Process
+
+### 1. Identify the PR
+
+```bash
+gh pr view --json number,url,title,baseRefName,headRefName
+```
+
+If `$ARGUMENTS` is a number, pass it: `gh pr view $ARGUMENTS --json ...`. Otherwise, detect from the current branch. If no PR is found, tell the user and exit.
+
+Also get the repo's owner/name for API calls:
+```bash
+gh repo view --json nameWithOwner --jq '.nameWithOwner'
+```
+
+**Ensure the working tree is on the PR's head branch.** If the current branch doesn't match `headRefName`, check it out now — otherwise file reads and edits will operate on the wrong code:
+
+```bash
+gh pr checkout <number>
+```
+
+### 2. Fetch Inline Review Comments
+
+Pull all review comments on the PR using the REST endpoint:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
+  --jq '.[] | {id, body, path, line, original_line, diff_hunk, in_reply_to_id, author: .user.login}' \
+  | jq -s '.'
+```
+
+Filter to top-level comments only (`in_reply_to_id` is null) — replies are context, not action items. Read any reply chains to understand the full discussion thread.
+
+### 3. Fetch Thread Resolution State
+
+The REST API doesn't expose whether a thread is resolved. Use a focused GraphQL query to get that, along with the node IDs you'll need for resolution later:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 100) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first: 1) {
+            nodes { databaseId }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+This gives you a mapping from REST `comment.id` (= `databaseId`) → GraphQL `thread.id` + `isResolved`. Discard threads that are already resolved.
+
+If `pageInfo.hasNextPage` is true, repeat the query with `reviewThreads(first: 100, after: "END_CURSOR")` until all threads are fetched.
+
+### 4. Read Code Context
+
+For each unresolved thread, read the current file at the referenced path. The `diff_hunk` field shows what the reviewer saw; reading the current file shows what's there now. Both matter for your decision.
+
+### 5. Decide: Implement or Decline
+
+**Implement the comment if:**
+- The suggestion is technically correct and would improve the code
+- The referenced code still exists in its original form (thread not outdated)
+- The change is within the scope of this PR
+- It doesn't conflict with project conventions or other changes being made
+
+**Decline the comment if:**
+- The code has already been changed to address the concern (outdated thread)
+- The suggestion is incorrect, would introduce a bug, or conflicts with project requirements
+- It's a style preference that conflicts with established codebase conventions
+- It's clearly out of scope (worth a follow-up issue, not this PR)
+- The reviewer misunderstood the code's intent and the current approach is correct
+
+When in doubt, lean toward implementing — reviewers raise things for a reason.
+
+### 6. Present Plan and Confirm
+
+Before touching anything, show the user a clear summary:
+
+```
+## PR Review Plan
+
+### Will implement (N):
+- [path:line] @username: "brief quote"
+  → What you'll change
+
+### Will decline (N):
+- [path:line] @username: "brief quote"
+  → Reason (this becomes your reply)
+
+Proceed?
+```
+
+Wait for the user's go-ahead. They know the codebase and may want to override your judgment.
+
+### 7. Implement Valid Changes
+
+Make each code change. Group changes in the same file into a single edit pass. Keep track of which thread corresponds to which change, and which GitHub login authored each suggestion.
+
+### 8. Commit with Commenter Credit
+
+Stage and commit all changes. Give credit using `Co-authored-by` trailers — GitHub recognizes the noreply email format:
+
+```
+Co-authored-by: username <username@users.noreply.github.com>
+```
+
+Example commit:
+```
+Address PR review feedback
+
+- Fix null check before dereferencing user object (suggested by @alice)
+- Rename `tmp` to `filteredResults` for clarity (suggested by @bob)
+- Extract magic number 42 to named constant MAX_RETRIES (suggested by @alice)
+
+Co-authored-by: alice <alice@users.noreply.github.com>
+Co-authored-by: bob <bob@users.noreply.github.com>
+```
+
+Deduplicate co-authors — one entry per person regardless of how many suggestions they made.
+
+**Commit fallbacks:**
+- If GPG signing fails, retry with `--no-gpg-sign`
+- If heredoc fails with "can't create temp file", write the message to a temp file and use `git commit -F <file>`
+
+### 9. Reply to Declined Comments
+
+For each declined comment, post a reply using the replies REST endpoint:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies \
+  --method POST \
+  --field body="Thanks for the suggestion. [Explanation of why not implementing]"
+```
+
+A good reply acknowledges the suggestion, gives a specific reason, and offers an alternative if appropriate (e.g., "I'll file a follow-up issue for this").
+
+### 10. Resolve Implemented Threads
+
+Resolve each thread that was addressed. Use the GraphQL node IDs captured in Step 3:
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "THREAD_NODE_ID"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+Do not resolve declined threads — leave them open so the reviewer can see your reply and respond.
+
+### 11. Report
+
+```
+## Done
+
+Implemented N comments → committed <hash>
+Declined N comments → replied with explanations
+
+[List of each action taken]
+```
+
+If the branch hasn't been pushed, mention: "Run `git push` to push the commit."
+
+## Notes
+
+- **No sandbox**: `gh` requires macOS keyring access. Run with sandbox disabled.
+- **Review threads vs. PR comments**: This skill handles inline code review threads. General PR body comments are out of scope.
+- **Multiple reviewers raised the same issue**: Give all of them credit in the commit message.
+- **Draft PRs**: Treat comments the same as on open PRs.

--- a/.agents/skills/pr-comments/SKILL.md
+++ b/.agents/skills/pr-comments/SKILL.md
@@ -32,7 +32,7 @@ Different operations require different `gh` commands:
 |------|---------|-----|
 | PR metadata | `gh pr view --json` | High-level; handles branch detection |
 | List review comments | `gh api repos/{owner}/{repo}/pulls/{number}/comments` | REST; simpler than GraphQL for reads |
-| Reply to a comment | `gh api repos/{owner}/{repo}/pulls/comments/{id}/replies` | REST; direct reply-to-comment endpoint |
+| Reply to a comment | `gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{id}/replies` | REST; direct reply-to-comment endpoint |
 | Get thread node IDs | `gh api graphql` | Thread node IDs only exist in GraphQL |
 | Resolve a thread | `gh api graphql` mutation | No REST equivalent for resolution |
 
@@ -176,7 +176,7 @@ Deduplicate co-authors — one entry per person regardless of how many suggestio
 For each declined comment, post a reply using the replies REST endpoint:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies \
+gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies \
   --method POST \
   --field body="Thanks for the suggestion. [Explanation of why not implementing]"
 ```

--- a/.agents/skills/pr-comments/SKILL.md
+++ b/.agents/skills/pr-comments/SKILL.md
@@ -63,22 +63,24 @@ Pull all review comments on the PR using the REST endpoint:
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
-  --jq '.[] | {id, body, path, line, original_line, diff_hunk, in_reply_to_id, author: .user.login}' \
+  --jq '.[] | {id, body, path, line, original_line, start_line, original_start_line, side, start_side, position, original_position, diff_hunk, in_reply_to_id, author: .user.login}' \
   | jq -s '.'
 ```
 
-Filter to top-level comments only (`in_reply_to_id` is null) — replies are context, not action items. Read any reply chains to understand the full discussion thread.
+When deciding on action items, focus on top-level comments (where `in_reply_to_id` is null); treat replies as context. Filter for these after fetching (for example, with `jq 'map(select(.in_reply_to_id == null))'`) and still read reply chains to understand the full discussion thread.
 
 ### 3. Fetch Thread Resolution State
 
 The REST API doesn't expose whether a thread is resolved. Use a focused GraphQL query to get that, along with the node IDs you'll need for resolution later:
 
 ```bash
-gh api graphql -f query='
-{
-  repository(owner: "OWNER", name: "REPO") {
-    pullRequest(number: PR_NUMBER) {
-      reviewThreads(first: 100) {
+gh api graphql \
+  -f owner=OWNER -f name=REPO -F number=PR_NUMBER \
+  -f query='
+query($owner: String!, $name: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
@@ -96,7 +98,7 @@ gh api graphql -f query='
 
 This gives you a mapping from REST `comment.id` (= `databaseId`) → GraphQL `thread.id` + `isResolved`. Discard threads that are already resolved.
 
-If `pageInfo.hasNextPage` is true, repeat the query with `reviewThreads(first: 100, after: "END_CURSOR")` until all threads are fetched.
+If `pageInfo.hasNextPage` is true, repeat the query passing `-f after=END_CURSOR` until all threads are fetched.
 
 ### 4. Read Code Context
 

--- a/.agents/skills/pr-comments/SKILL.md
+++ b/.agents/skills/pr-comments/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   review feedback", "process PR review comments", or wants to work through open
   review threads on their pull request. Gives credit to commenters in commit messages.
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication
+compatibility: Requires git, jq, and GitHub CLI (gh) with authentication
 metadata:
   author: Gregory Murray
   repository: github.com/whatifwedigdeeper/agent-skills

--- a/.claude/skills/pr-comments
+++ b/.claude/skills/pr-comments
@@ -1,0 +1,1 @@
+../../.agents/skills/pr-comments

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Skills installed from [WhatIfWeDigDeeper/agent-skills](https://github.com/WhatIf
 | `js-deps` | Update npm dependencies and/or fix audit errors |
 | `uv-deps` | Audit and update Python dependencies |
 | `ship-it` | Branch, commit, push, and open a PR |
+| `pr-comments` | Address review comments on a pull request |
 
 Since `npx skills check` and `npx skills update` apparently do not work with the above repo at this time, you may force update all skills:
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -14,7 +14,7 @@
     "pr-comments": {
       "source": "whatifwedigdeeper/agent-skills",
       "sourceType": "github",
-      "computedHash": "0987ccc66fa96c0b5916e095f0bd314fb30c0284e02829db6af690f404f377bb"
+      "computedHash": "e15f803f7677ef5b460e2fba09b42f44107d607982fa5346a6456dc10a875d22"
     },
     "ship-it": {
       "source": "whatifwedigdeeper/agent-skills",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,12 +4,17 @@
     "js-deps": {
       "source": "whatifwedigdeeper/agent-skills",
       "sourceType": "github",
-      "computedHash": "4ec92eb6ace92623313f558bc79c8ff210cfea03fc2870ee0f1fed89345163b2"
+      "computedHash": "192a3c879a7e38aac1c52187bf0fc1e1ff9e50ada25e7ee11f8e3dd0477525da"
     },
     "learn": {
       "source": "whatifwedigdeeper/agent-skills",
       "sourceType": "github",
       "computedHash": "f5ceaf17d0aeebfaf15db5980c0fa63e27a65ba9fa52caccd7d3f45190da10bc"
+    },
+    "pr-comments": {
+      "source": "whatifwedigdeeper/agent-skills",
+      "sourceType": "github",
+      "computedHash": "d12a5c3be8f49502051d706b7e4d48333680dd5779c25602efb31cd1d310ede6"
     },
     "ship-it": {
       "source": "whatifwedigdeeper/agent-skills",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -14,7 +14,7 @@
     "pr-comments": {
       "source": "whatifwedigdeeper/agent-skills",
       "sourceType": "github",
-      "computedHash": "e15f803f7677ef5b460e2fba09b42f44107d607982fa5346a6456dc10a875d22"
+      "computedHash": "2d9d0c4ddbb17b50cb2056e8d45a3c953a755a4908686281a3c5adcdfe109382"
     },
     "ship-it": {
       "source": "whatifwedigdeeper/agent-skills",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "js-deps": {
       "source": "whatifwedigdeeper/agent-skills",
       "sourceType": "github",
-      "computedHash": "192a3c879a7e38aac1c52187bf0fc1e1ff9e50ada25e7ee11f8e3dd0477525da"
+      "computedHash": "08c5e55b53bc30753d6672b24ccfaf6c64e94461e8aed7f1b9dd452269c3be8f"
     },
     "learn": {
       "source": "whatifwedigdeeper/agent-skills",
@@ -14,7 +14,7 @@
     "pr-comments": {
       "source": "whatifwedigdeeper/agent-skills",
       "sourceType": "github",
-      "computedHash": "d12a5c3be8f49502051d706b7e4d48333680dd5779c25602efb31cd1d310ede6"
+      "computedHash": "0987ccc66fa96c0b5916e095f0bd314fb30c0284e02829db6af690f404f377bb"
     },
     "ship-it": {
       "source": "whatifwedigdeeper/agent-skills",


### PR DESCRIPTION
## Summary
- Add `pr-comments` skill entry to the Skills table in README.md
- Add `jq` to compatibility requirements in pr-comments skill
- Replace Unicode arrow with ASCII `->` in js-deps update-workflow
- Use `dirname` subshell for worktree path construction in js-deps
- Use subshell for `cd` in corrupted lockfile fix to preserve cwd
- Add range comment fields (`start_line`, `side`, `position`, etc.) to `--jq` projection
- Clarify filtering prose: top-level comment selection happens after fetch
- Use GraphQL variables (`-f owner`, `-f name`, `-F number`) instead of hardcoded strings
- Fix reply endpoint URL: must include PR number in path (`/pulls/{number}/comments/{id}/replies`)

## Test plan
- [ ] Verify the README Skills table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)