### PR TITLE
chore: bump GitHub Actions versions in verify-pr workflow

### DIFF
--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Check for docs-only changes
         id: docs-check
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             docs/**
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install uv and Python
         if: steps.docs-check.outputs.only_changed == 'false'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.14'
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Set up Gradle
         if: steps.docs-check.outputs.only_changed == 'false'
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Get date for NVD cache key
         if: steps.docs-check.outputs.only_changed == 'false'


### PR DESCRIPTION
## Summary
- Bump `tj-actions/changed-files` from v46 → v47
- Bump `astral-sh/setup-uv` from v5 → v7
- Bump `gradle/actions/setup-gradle` from v4 → v5

## Test Plan
- [ ] CI passes on this PR with the updated action versions

---
Generated with [Claude Code](https://claude.com/claude-code)