### PR TITLE
chore: switch notification hooks to terminal-notifier with Glass sound

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "osascript -e 'display notification \"Claude Code needs your permission\" with title \"Claude Code\"'"
+            "command": "terminal-notifier -title 'Claude Code' -message 'Claude needs your permission' -sound Glass"
           }
         ]
       },
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "osascript -e 'display notification \"Claude has a question for you\" with title \"Claude Code\"'"
+            "command": "terminal-notifier -title 'Claude Code' -message 'Claude has a question for you' -sound Glass"
           }
         ]
       },
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "osascript -e 'display notification \"Claude is waiting for your input\" with title \"Claude Code\"'"
+            "command": "terminal-notifier -title 'Claude Code' -message 'Claude is waiting for your input' -sound Glass"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Replaces `osascript` notification commands with `terminal-notifier` for Claude Code permission/question/waiting hooks
- Adds `Glass` sound to all three notification types for better audibility

## Test Plan

- [x] Trigger a permission prompt in Claude Code and verify `terminal-notifier` notification appears with sound

🤖 Generated with [Claude Code](https://claude.com/claude-code)