### PR TITLE
chore: set default model to opusplan and sort cspell wordlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "opusplan",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -4,15 +4,13 @@ dictionaryDefinitions: []
 dictionaries: []
 words:
   - asyncpg
-  - debugpy
-  - dquote
-  - networkidle
-  - VARCHAR
   - auditconfig
   - beforeunload
+  - debugpy
   - dedup
   - Dedup
   - domcontentloaded
+  - dquote
   - fastapi
   - golangci
   - gopath
@@ -24,11 +22,13 @@ words:
   - Hono
   - mongosh
   - mypy
+  - networkidle
   - Nuxt
+  - opusplan
   - osascript
+  - psql
   - Pydantic
   - pyproject
-  - psql
   - pytest
   - RYUK
   - specifykit
@@ -43,6 +43,7 @@ words:
   - unsubmitted
   - Unsubmitted
   - uvx
+  - VARCHAR
   - venv
   - whatifwedigdeeper
   - worktree


### PR DESCRIPTION
## Summary
- Set default Claude Code model to `opusplan` in `.claude/settings.json`
- Sort `cspell.config.yaml` wordlist alphabetically and add `opusplan`

## Test plan
- [ ] Verify CI passes (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
