### PR TITLE
chore: use project name in notifications, skip dependabot in code review

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "terminal-notifier -title 'application-tracker' -message 'Claude needs your permission' -sound Glass"
+            "command": "terminal-notifier -title 'application-tracker' -message 'Claude needs your permission' -sound Glass -activate com.microsoft.VSCode"
           }
         ]
       },
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "terminal-notifier -title 'application-tracker' -message 'Claude has a question for you' -sound Glass"
+            "command": "terminal-notifier -title 'application-tracker' -message 'Claude has a question for you' -sound Glass -activate com.microsoft.VSCode"
           }
         ]
       },
@@ -50,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "terminal-notifier -title 'application-tracker' -message 'Claude is waiting for your input' -sound Glass"
+            "command": "terminal-notifier -title 'application-tracker' -message 'Claude is waiting for your input' -sound Glass -activate com.microsoft.VSCode"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "terminal-notifier -title 'Claude Code' -message 'Claude needs your permission' -sound Glass"
+            "command": "terminal-notifier -title 'application-tracker' -message 'Claude needs your permission' -sound Glass"
           }
         ]
       },
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "terminal-notifier -title 'Claude Code' -message 'Claude has a question for you' -sound Glass"
+            "command": "terminal-notifier -title 'application-tracker' -message 'Claude has a question for you' -sound Glass"
           }
         ]
       },
@@ -50,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "terminal-notifier -title 'Claude Code' -message 'Claude is waiting for your input' -sound Glass"
+            "command": "terminal-notifier -title 'application-tracker' -message 'Claude is waiting for your input' -sound Glass"
           }
         ]
       }

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Use project name (`application-tracker`) instead of `Claude Code` in terminal-notifier notification titles for clearer context when multiple projects are open
- Wire up the notification "Show" button to activate VS Code via `-activate com.microsoft.VSCode`
- Skip Claude code review for `dependabot[bot]` PRs to avoid unnecessary API usage on automated dependency updates

## Test Plan
- [ ] Trigger a permission prompt — notification title should show `application-tracker` and clicking "Show" should bring VS Code to the foreground
- [ ] Open a Dependabot PR to verify the claude-review job is skipped

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)