### PR TITLE
fix: upgrade Go toolchain to 1.26.2 to resolve stdlib vulnerabilities

### DIFF
--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -89,7 +89,7 @@ jobs:
         if: steps.docs-check.outputs.only_changed == 'false'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go-api/go.mod
           cache-dependency-path: go-api/go.sum
 
       - name: Install govulncheck

--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ Thumbs.db
 
 # Claude settings
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 .playwright-cli
 

--- a/go-api/go.mod
+++ b/go-api/go.mod
@@ -1,6 +1,6 @@
 module github.com/user/application-tracker/go-api
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/gin-gonic/gin v1.10.0


### PR DESCRIPTION
## Summary
- Bumps `go.mod` from `go 1.26.1` to `go 1.26.2` to resolve 5 Go standard library vulnerabilities
- `govulncheck` now reports 0 vulnerabilities (down from 5)
- Build and `go vet` pass cleanly with go1.26.2

## Vulnerabilities Fixed

| ID | Package | Description |
|----|---------|-------------|
| GO-2026-4947 | `crypto/x509` | Unexpected work during chain building |
| GO-2026-4946 | `crypto/x509` | Inefficient policy validation |
| GO-2026-4870 | `crypto/tls` | Unauthenticated TLS 1.3 KeyUpdate causes DoS |
| GO-2026-4866 | `crypto/x509` | Case-sensitive excludedSubtrees name constraints auth bypass |
| GO-2026-4865 | `html/template` | JsBraceDepth context tracking bugs (XSS) |

## Changes
- `go-api/go.mod`: `go 1.26.1` → `go 1.26.2` (1-line change)

## Validation
- `govulncheck ./...`: 0 vulnerabilities
- `go build ./...`: pass
- `go vet ./...`: pass

Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up commit
- Switched CI Go setup from \`go-version: '1.26'\` to \`go-version-file: go-api/go.mod\` per Copilot review feedback, so the exact patched toolchain is always used.