### PR TITLE
fix: patch vulnerable Python dependencies

### DIFF
--- a/fastapi/migrations/run.py
+++ b/fastapi/migrations/run.py
@@ -43,7 +43,7 @@ async def run_migrations() -> None:
                 "INSERT INTO python_fastapi.schema_migrations (migration_name) VALUES ($1)",
                 name,
             )
-            print(f"  Done.")
+            print("  Done.")
     finally:
         await conn.close()
 

--- a/fastapi/pyproject.toml
+++ b/fastapi/pyproject.toml
@@ -8,8 +8,8 @@ dependencies = [
     "uvicorn[standard]==0.34.2",
     "asyncpg==0.31.0",
     "pydantic==2.12.5",
-    "python-dotenv==1.1.0",
-    "python-multipart==0.0.22",
+    "python-dotenv==1.2.2",
+    "python-multipart==0.0.26",
 ]
 
 [project.optional-dependencies]

--- a/fastapi/uv.lock
+++ b/fastapi/uv.lock
@@ -139,8 +139,8 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.0.0" },
-    { name = "python-dotenv", specifier = "==1.1.0" },
-    { name = "python-multipart", specifier = "==0.0.22" },
+    { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "python-multipart", specifier = "==0.0.26" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.1" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.34.2" },
 ]
@@ -456,20 +456,20 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.0"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Fixed 2 vulnerabilities in the `fastapi` Python package
- `python-dotenv` 1.1.0 → 1.2.2 (CVE-2026-28684 / GHSA-mf9w-mj56-hr94)
- `python-multipart` 0.0.22 → 0.0.26 (CVE-2026-40347 / GHSA-mj87-hwqh-73pj)
- Also fixed a pre-existing ruff lint warning (`F541`) in `migrations/run.py`

## Changes
| Package | Before | After | CVE |
|---------|--------|-------|-----|
| python-dotenv | 1.1.0 | 1.2.2 | CVE-2026-28684 — symlink-follow file overwrite |
| python-multipart | 0.0.22 | 0.0.26 | CVE-2026-40347 — multipart parsing DoS |

## Validation Results
| Check | Status |
|-------|--------|
| Lint (ruff) | ✅ pass |
| Tests (pytest) | ✅ pass (59/59) |
| Security Audit (pip-audit) | ✅ 0 vulnerabilities remaining |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
