### PR TITLE
fix(deps): bump simple-git in nuxt-api to patch GHSA-hffm-xvc3-vprc

### DIFF
--- a/nuxt-api/package-lock.json
+++ b/nuxt-api/package-lock.json
@@ -4056,18 +4056,18 @@
       ]
     },
     "node_modules/@simple-git/args-pathspec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.2.tgz",
-      "integrity": "sha512-nEFVejViHUoL8wU8GTcwqrvqfUG40S5ts6S4fr1u1Ki5CklXlRDYThPVA/qurTmCYFGnaX3XpVUmICLHdvhLaA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
       "license": "MIT"
     },
     "node_modules/@simple-git/argv-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.0.3.tgz",
-      "integrity": "sha512-NMKv9sJcSN2VvnPT9Ja7eKfGy8Q8mMFLwPTCcuZMtv3+mYcLIZflg31S/tp2XCCyiY7YAx6cgBHQ0fwA2fWHpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
       "license": "MIT",
       "dependencies": {
-        "@simple-git/args-pathspec": "^1.0.2"
+        "@simple-git/args-pathspec": "^1.0.3"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -10180,15 +10180,15 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.35.2",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.35.2.tgz",
-      "integrity": "sha512-ZMjl06lzTm1EScxEGuM6+mEX+NQd14h/B3x0vWU+YOXAMF8sicyi1K4cjTfj5is+35ChJEHDl1EjypzYFWH2FA==",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "@simple-git/args-pathspec": "^1.0.2",
-        "@simple-git/argv-parser": "^1.0.3",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
         "debug": "^4.4.0"
       },
       "funding": {

--- a/react-apollo-ui/package-lock.json
+++ b/react-apollo-ui/package-lock.json
@@ -5029,18 +5029,18 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
-      "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
+      "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/seroval-plugins": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.2.tgz",
-      "integrity": "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.4.tgz",
+      "integrity": "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/tanstack-start-ui/package-lock.json
+++ b/tanstack-start-ui/package-lock.json
@@ -5761,18 +5761,18 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
-      "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
+      "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/seroval-plugins": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.2.tgz",
-      "integrity": "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.4.tgz",
+      "integrity": "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"


### PR DESCRIPTION
## Summary

Resolves the high-severity Remote Code Execution advisory [GHSA-hffm-xvc3-vprc](https://github.com/advisories/GHSA-hffm-xvc3-vprc) by bumping the transitive `simple-git` from 3.35.2 → 3.36.0 (via `npm audit fix`). Pulled in via `nuxt → @nuxt/devtools → simple-git`. Other packages in the monorepo do not depend on `simple-git`, so no other lockfiles change.

> Note on wording: "patch" in the PR title is used as a verb ("apply a fix") — it does **not** imply a semver patch-level bump. 3.35.2 → 3.36.0 is a minor bump, which is what `npm audit fix` recommends as the smallest available fix for this advisory.

CI's `audit:ci:all` step has been failing on this advisory on every PR opened against `main`, blocking merges.

This commit was cherry-picked from `feat/understand-codebase-graphs` (commit `f063bf3`) so the fix can land independently of that feature branch's review cycle.

## Test plan

- [x] `cd nuxt-api && npx -y audit-ci --config .auditconfig.json` passes locally.
- [ ] CI `audit:ci:all` passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update — additional pre-existing CI breakages folded in (seroval lockfile sync)

After pushing the simple-git fix, CI surfaced additional pre-existing main-level breakages that had been masked by the audit failure: `npm ci` was failing in **both** `tanstack-start-ui/` and `react-apollo-ui/` with:

```
npm error Invalid: lock file's seroval@1.5.2 does not satisfy seroval@1.5.4
npm error Invalid: lock file's seroval-plugins@1.5.2 does not satisfy seroval-plugins@1.5.4
```

`npm install` in each of those directories regenerates their lockfiles to 1.5.4 for both packages. Folded into this PR because (a) they're the same shape of pre-existing main breakage and (b) all three must land before any open PR can pass CI. PRs #305 and #306 are blocked on this PR landing.

Commits in this PR:

- `9331aa9` fix(deps): bump simple-git in nuxt-api to patch GHSA-hffm-xvc3-vprc
- `1ade966` fix(deps): sync tanstack-start-ui lockfile (seroval 1.5.2 → 1.5.4)
- `ec44aef` fix(deps): sync react-apollo-ui lockfile (seroval 1.5.2 → 1.5.4)
